### PR TITLE
Optimize informer cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ gosec-report.sarif
 .idea
 
 receiver/gardenerreceiver/bench-memory.txt
+receiver/gardenerreceiver/mem.prof
+receiver/gardenerreceiver/gardenerreceiver.test

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ _build/
 gosec-report.sarif
 
 .idea
+
+receiver/gardenerreceiver/bench-memory.txt

--- a/receiver/gardenerreceiver/Makefile
+++ b/receiver/gardenerreceiver/Makefile
@@ -3,3 +3,19 @@
 # SPDX-License-Identifier: Apache-2.0
 
 include ../../Makefile.Common
+
+.PHONY: bench-memory bench-memory-profile
+
+# Steady-state and churn memory benchmarks. Build-tagged so they don't run in
+# normal `go test ./...`. count=5 gives benchstat enough samples to call
+# significance across PRs.
+bench-memory:
+	go test -tags=bench -run=^$$ -bench=. -benchmem -benchtime=1x -count=5 \
+	    -timeout=30m ./... | tee bench-memory.txt
+
+# Heap profile of the largest scale point. Useful for diagnosing what dominates
+# the cache footprint (annotations, managedFields, status conditions, ...).
+bench-memory-profile:
+	go test -tags=bench -run=^$$ -bench=BenchmarkScale_ShootCache/N=10000 \
+	    -memprofile=mem.prof -benchtime=1x ./...
+	go tool pprof -top -unit=mb mem.prof

--- a/receiver/gardenerreceiver/bench_churn_test.go
+++ b/receiver/gardenerreceiver/bench_churn_test.go
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build bench
+
+package gardenerreceiver
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"testing"
+	"time"
+
+	gardenerfake "github.com/gardener/gardener/pkg/client/core/clientset/versioned/fake"
+	gardenerinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apiruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
+)
+
+// BenchmarkChurn_ShootCache fixes N shoots in the cache, applies M updates
+// across them, then reports the resulting cache memory footprint.
+//
+// The question this benchmark answers: does churn inflate the cache, or does
+// it settle back to the same footprint as a fresh cache of size N?
+//
+// A healthy informer plateaus — heap after M updates should equal the steady
+// state from BenchmarkScale_ShootCache at the same N. A growing footprint
+// indicates retained references, growing indices, or a leak in the transform
+// path.
+//
+// Run as:
+//
+//	go test -tags=bench -bench=BenchmarkChurn -run=^$ \
+//	    -benchtime=1x -count=5 -timeout=30m
+func BenchmarkChurn_ShootCache(b *testing.B) {
+	const shootCount = 5_000
+	for _, updateCount := range []int{shootCount, 10 * shootCount, 100 * shootCount} {
+		b.Run(fmt.Sprintf("shoots=%d/updates=%d", shootCount, updateCount), func(b *testing.B) {
+			runChurn(b, shootCount, updateCount)
+		})
+	}
+}
+
+func runChurn(b *testing.B, shootCount, updateCount int) {
+	b.ReportAllocs()
+
+	initialShoots := make([]apiruntime.Object, shootCount)
+	for idx := 0; idx < shootCount; idx++ {
+		initialShoots[idx] = makeShoot(idx)
+	}
+	gardenClient := gardenerfake.NewSimpleClientset(initialShoots...)
+	shootFactory := gardenerinformers.NewSharedInformerFactoryWithOptions(
+		gardenClient, 0,
+		gardenerinformers.WithTransform(transformShoot),
+	)
+	shootInformer := shootFactory.Core().V1beta1().Shoots().Informer()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	shootFactory.Start(ctx.Done())
+	if !cache.WaitForCacheSync(ctx.Done(), shootInformer.HasSynced) {
+		b.Fatal("informer cache failed to sync")
+	}
+	initialShoots = nil
+
+	// Baseline: cache filled, no churn yet. This is the reference point.
+	baseline := memSnapshot()
+
+	tracker := gardenClient.Tracker()
+	// The fake clientset's watch channel has a small fixed buffer and panics
+	// on overflow rather than blocking. Yield frequently and pause briefly
+	// in larger batches so the informer can drain — this is plumbing, not
+	// throughput throttling.
+	for updateIdx := 0; updateIdx < updateCount; updateIdx++ {
+		updated := makeShoot(updateIdx % shootCount)
+		updated.ResourceVersion = fmt.Sprintf("%d", updateIdx+shootCount)
+		updated.Generation = int64(updateIdx)
+		updated.Status.LastOperation.LastUpdateTime = metav1.Time{Time: time.Now()}
+		if err := tracker.Update(shootGVR, updated, benchNamespace); err != nil {
+			b.Fatalf("tracker update failed: %v", err)
+		}
+		if updateIdx%50 == 0 {
+			time.Sleep(time.Millisecond)
+		}
+	}
+
+	// Give the informer's processing loop a moment to drain queued events
+	// before sampling. Without this we'd measure mid-flight allocations
+	// rather than the settled cache.
+	drainInformer(shootInformer, shootCount)
+
+	afterChurn := memSnapshot()
+	b.ReportMetric(diffMiB(afterChurn.HeapAlloc, baseline.HeapAlloc), "churn_heap_growth_MiB")
+	b.ReportMetric(diffMiB(afterChurn.HeapInuse, baseline.HeapInuse), "churn_inuse_growth_MiB")
+	b.ReportMetric(float64(afterChurn.HeapAlloc)/float64(1<<20), "post_churn_heap_MiB")
+	b.ReportMetric(float64(afterChurn.NumGC-baseline.NumGC), "churn_gc_cycles")
+	b.ReportMetric(float64(len(shootInformer.GetStore().ListKeys())), "cached_objects")
+
+	runtime.KeepAlive(shootInformer)
+}
+
+// drainInformer waits until the informer has processed pending watch events.
+// Heuristic: poll the store size — once it's stable across a few ticks and
+// equal to the expected count, the queue has drained.
+func drainInformer(informer cache.SharedIndexInformer, expectedSize int) {
+	const requiredStableTicks = 5
+	stableTickCount := 0
+	lastSize := -1
+	for stableTickCount < requiredStableTicks {
+		time.Sleep(20 * time.Millisecond)
+		currentSize := len(informer.GetStore().ListKeys())
+		if currentSize == lastSize && currentSize == expectedSize {
+			stableTickCount++
+		} else {
+			stableTickCount = 0
+			lastSize = currentSize
+		}
+	}
+}

--- a/receiver/gardenerreceiver/bench_helpers_test.go
+++ b/receiver/gardenerreceiver/bench_helpers_test.go
@@ -1,0 +1,459 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build bench
+
+package gardenerreceiver
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	corev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apiruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+)
+
+// The synthetic Shoot built by makeShoot mirrors the structural shape of a
+// real Gardener Shoot resource (counts and field types are taken from a
+// production example), but every value is a generic placeholder. Personal
+// identifiers, internal landscape topology, IP ranges, cluster UIDs, and
+// version hashes from the real example were intentionally NOT copied — only
+// the shape is preserved, since it's the shape that determines cache
+// memory footprint.
+//
+// In particular, the helper populates every field that transformShoot is
+// designed to strip, so the benchmark exercises the full optimization path:
+//
+//   ObjectMeta:      Annotations, Labels, ManagedFields, Finalizers,
+//                    OwnerReferences
+//   Spec:            Networking (with ProviderConfig), Tolerations,
+//                    SystemComponents, CloudProfile, ExposureClassName,
+//                    SchedulerName, KubeAPIServer.* (Requests, Logging,
+//                    EncryptionConfig, EventTTL, …)
+//   Spec.Provider:   InfrastructureConfig, ControlPlaneConfig,
+//                    WorkersSettings; per-worker ProviderConfig,
+//                    UpdateStrategy, MaxSurge, MaxUnavailable,
+//                    SystemComponents
+//   Status:          AdvertisedAddresses, ClusterIdentity, Credentials,
+//                    SeedName, LastHibernationTriggerTime, LastMaintenance,
+//                    Networking, LastErrors; LastOperation.Description and
+//                    LastUpdateTime
+//
+// Fields populated below but NOT touched by transformShoot (e.g. Conditions,
+// Constraints, Spec.Hibernation) reflect realistic shoot bloat that the
+// receiver legitimately keeps in cache; their inclusion makes the absolute
+// post-transform footprint realistic too.
+
+const benchNamespace = "garden-bench"
+
+// makeShoot builds a synthetic Shoot whose structure matches a real one.
+// The idx parameter is mixed into a few fields so that updates carry distinct
+// payloads (avoids collapsing into a single canonical object on the heap
+// via string interning of identical literals).
+func makeShoot(idx int) *corev1beta1.Shoot {
+	name := fmt.Sprintf("shoot-%06d", idx)
+	uid := fmt.Sprintf("00000000-0000-0000-0000-%012d", idx)
+
+	return &corev1beta1.Shoot{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "core.gardener.cloud/v1beta1",
+			Kind:       "Shoot",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         benchNamespace,
+			UID:               types.UID(uid),
+			ResourceVersion:   fmt.Sprintf("%d", idx),
+			Generation:        int64(1000 + idx),
+			CreationTimestamp: metav1.Time{Time: time.Now().Add(-30 * 24 * time.Hour)},
+			Annotations:       makeAnnotations(),
+			Labels:            makeLabels(),
+			Finalizers: []string{
+				"gardener",
+				"core.gardener.cloud/controllerregistration",
+			},
+			ManagedFields:   makeManagedFields(),
+			OwnerReferences: makeOwnerReferences(uid),
+		},
+		Spec:   makeShootSpec(idx),
+		Status: makeShootStatus(idx),
+	}
+}
+
+// makeAnnotations returns annotations with realistic key prefixes and a
+// neutral creator value (no real email).
+func makeAnnotations() map[string]string {
+	return map[string]string{
+		"gardener.cloud/created-by":       "bench@example.invalid",
+		"shoot.gardener.cloud/tasks":      "deployInfrastructure",
+		"gardener.cloud/operation-status": "ok",
+	}
+}
+
+// makeLabels mirrors the count and key shape of the real example
+// (~11 extension/provider labels) without copying internal extension names
+// that aren't already public.
+func makeLabels() map[string]string {
+	return map[string]string{
+		"extensions.extensions.gardener.cloud/image-rewriter":                   "true",
+		"extensions.extensions.gardener.cloud/shoot-cert-service":               "true",
+		"extensions.extensions.gardener.cloud/shoot-dns-service":                "true",
+		"extensions.extensions.gardener.cloud/shoot-networking-filter":          "true",
+		"extensions.extensions.gardener.cloud/shoot-networking-problemdetector": "true",
+		"name.seed.gardener.cloud/bench-seed":                                   "true",
+		"networking.extensions.gardener.cloud/calico":                           "true",
+		"operatingsystemconfig.extensions.gardener.cloud/gardenlinux":           "true",
+		"provider.extensions.gardener.cloud/example":                            "true",
+		"shoot.gardener.cloud/status":                                           "healthy",
+	}
+}
+
+// makeManagedFields produces five entries with FieldsV1 blobs of the size
+// real serializations carry. The blob content is a meaningless byte pattern.
+func makeManagedFields() []metav1.ManagedFieldsEntry {
+	const entryCount = 5
+	entries := make([]metav1.ManagedFieldsEntry, 0, entryCount)
+	fieldsBlob := []byte(strings.Repeat(`{"f:metadata":{"f:annotations":{}}}`, 60))
+	for idx := 0; idx < entryCount; idx++ {
+		entries = append(entries, metav1.ManagedFieldsEntry{
+			Manager:    fmt.Sprintf("gardener-controller-%d", idx),
+			Operation:  metav1.ManagedFieldsOperationUpdate,
+			APIVersion: "core.gardener.cloud/v1beta1",
+			Time:       &metav1.Time{Time: time.Now()},
+			FieldsType: "FieldsV1",
+			FieldsV1:   &metav1.FieldsV1{Raw: fieldsBlob},
+		})
+	}
+	return entries
+}
+
+func makeOwnerReferences(uid string) []metav1.OwnerReference {
+	// Single owner reference is typical; included so transformShoot has
+	// something to clear.
+	return []metav1.OwnerReference{{
+		APIVersion: "core.gardener.cloud/v1beta1",
+		Kind:       "Project",
+		Name:       "bench-project",
+		UID:        types.UID(uid),
+	}}
+}
+
+// makeShootSpec assembles a spec with four worker pools, full kubeAPIServer
+// config block, networking with provider config, hibernation schedule and
+// maintenance window. Field counts match the real example.
+func makeShootSpec(idx int) corev1beta1.ShootSpec {
+	hibernationEnabled := false
+	hibernationStart := "00 20 * * 1,3,4,5,6,0,2"
+	hibernationLocation := "Europe/Berlin"
+	autoUpdateMachineImage := true
+
+	apiAudiences := []string{"kubernetes"}
+	eventTTL := metav1.Duration{Duration: time.Hour}
+
+	infraConfig := apiruntime.RawExtension{
+		Raw: []byte(`{"apiVersion":"example.provider.extensions.gardener.cloud/v1alpha1","kind":"InfrastructureConfig","networks":{"workers":"10.0.0.0/16"}}`),
+	}
+	controlPlaneConfig := apiruntime.RawExtension{
+		Raw: []byte(`{"apiVersion":"example.provider.extensions.gardener.cloud/v1alpha1","kind":"ControlPlaneConfig","loadBalancerProvider":"default"}`),
+	}
+	networkingProviderConfig := apiruntime.RawExtension{
+		Raw: []byte(`{"birdExporter":{"enabled":true},"overlay":{"enabled":true}}`),
+	}
+	dnsExtensionConfig := apiruntime.RawExtension{
+		Raw: []byte(`{"apiVersion":"service.dns.extensions.gardener.cloud/v1alpha1","kind":"DNSConfig","syncProvidersFromShootSpecDNS":true}`),
+	}
+
+	return corev1beta1.ShootSpec{
+		CloudProfile: &corev1beta1.CloudProfileReference{
+			Kind: "CloudProfile",
+			Name: "bench-cloud-profile",
+		},
+		CredentialsBindingName: ptr.To("bench-credentials-binding"),
+		DNS: &corev1beta1.DNS{
+			Domain: ptr.To(fmt.Sprintf("shoot-%06d.bench.example.invalid", idx)),
+		},
+		Extensions: []corev1beta1.Extension{{
+			Type:           "shoot-dns-service",
+			ProviderConfig: &dnsExtensionConfig,
+		}},
+		Hibernation: &corev1beta1.Hibernation{
+			Enabled: &hibernationEnabled,
+			Schedules: []corev1beta1.HibernationSchedule{{
+				Start:    &hibernationStart,
+				Location: &hibernationLocation,
+			}},
+		},
+		Kubernetes: corev1beta1.Kubernetes{
+			Version: "1.34.6",
+			KubeAPIServer: &corev1beta1.KubeAPIServerConfig{
+				DefaultNotReadyTolerationSeconds:    ptr.To[int64](300),
+				DefaultUnreachableTolerationSeconds: ptr.To[int64](300),
+				EventTTL:                            &eventTTL,
+				APIAudiences:                        apiAudiences,
+				Logging: &corev1beta1.APIServerLogging{
+					Verbosity: ptr.To[int32](2),
+				},
+				Requests: &corev1beta1.APIServerRequests{
+					MaxMutatingInflight:    ptr.To[int32](200),
+					MaxNonMutatingInflight: ptr.To[int32](400),
+				},
+				EncryptionConfig: &corev1beta1.EncryptionConfig{
+					Resources: []string{"secrets"},
+				},
+			},
+		},
+		Maintenance: &corev1beta1.Maintenance{
+			AutoUpdate: &corev1beta1.MaintenanceAutoUpdate{
+				KubernetesVersion:   true,
+				MachineImageVersion: &autoUpdateMachineImage,
+			},
+			TimeWindow: &corev1beta1.MaintenanceTimeWindow{
+				Begin: "020000+0200",
+				End:   "030000+0200",
+			},
+		},
+		Networking: &corev1beta1.Networking{
+			Type:           ptr.To("calico"),
+			Nodes:          ptr.To("10.0.0.0/16"),
+			Pods:           ptr.To("100.64.0.0/12"),
+			Services:       ptr.To("100.104.0.0/13"),
+			IPFamilies:     []corev1beta1.IPFamily{corev1beta1.IPFamilyIPv4},
+			ProviderConfig: &networkingProviderConfig,
+		},
+		Provider: corev1beta1.Provider{
+			Type:                 "example",
+			InfrastructureConfig: &infraConfig,
+			ControlPlaneConfig:   &controlPlaneConfig,
+			Workers:              makeWorkers(),
+			WorkersSettings: &corev1beta1.WorkersSettings{
+				SSHAccess: &corev1beta1.SSHAccess{Enabled: true},
+			},
+		},
+		Purpose:           ptr.To(corev1beta1.ShootPurpose("evaluation")),
+		Region:            "bench-region-1",
+		SeedName:          ptr.To(fmt.Sprintf("bench-seed-%d", idx%20)),
+		SchedulerName:     ptr.To("default-scheduler"),
+		ExposureClassName: ptr.To("standard"),
+		SystemComponents: &corev1beta1.SystemComponents{
+			CoreDNS: &corev1beta1.CoreDNS{
+				Autoscaling: &corev1beta1.CoreDNSAutoscaling{
+					Mode: corev1beta1.CoreDNSAutoscalingModeHorizontal,
+				},
+			},
+			NodeLocalDNS: &corev1beta1.NodeLocalDNS{
+				Enabled: true,
+			},
+		},
+	}
+}
+
+// makeWorkers builds four worker pools with sizes/zones matching the real
+// example shape. Per-pool ProviderConfig is populated so transformShoot has
+// something non-trivial to drop.
+func makeWorkers() []corev1beta1.Worker {
+	zones := []string{"bench-1a", "bench-1b", "bench-1c"}
+	pools := []struct {
+		name      string
+		machine   string
+		min, max  int32
+		hasLabels bool
+	}{
+		{"small", "bench.c2.m4", 0, 6, false},
+		{"large", "bench.c16.m32", 0, 10, true},
+		{"larger", "bench.c16.m64", 0, 10, true},
+		{"largest", "bench.c32.m128", 0, 3, false},
+	}
+
+	workers := make([]corev1beta1.Worker, 0, len(pools))
+	providerConfig := apiruntime.RawExtension{
+		Raw: []byte(`{"apiVersion":"example.provider.extensions.gardener.cloud/v1alpha1","kind":"WorkerConfig"}`),
+	}
+	for _, pool := range pools {
+		worker := corev1beta1.Worker{
+			Name: pool.name,
+			CRI: &corev1beta1.CRI{
+				Name: corev1beta1.CRINameContainerD,
+			},
+			Machine: corev1beta1.Machine{
+				Type:         pool.machine,
+				Architecture: ptr.To("amd64"),
+				Image: &corev1beta1.ShootMachineImage{
+					Name:    "gardenlinux",
+					Version: ptr.To("2150.4.0"),
+				},
+			},
+			Maximum:        pool.max,
+			Minimum:        pool.min,
+			MaxSurge:       intOrStringPtr(1),
+			MaxUnavailable: intOrStringPtr(0),
+			Zones:          zones,
+			SystemComponents: &corev1beta1.WorkerSystemComponents{
+				Allow: true,
+			},
+			UpdateStrategy: ptr.To(corev1beta1.AutoRollingUpdate),
+			ProviderConfig: &providerConfig,
+		}
+		if pool.hasLabels {
+			worker.Labels = map[string]string{"pool": "demo-pods"}
+		}
+		workers = append(workers, worker)
+	}
+	return workers
+}
+
+// makeShootStatus mirrors the status block of a fully reconciled shoot:
+// 5 conditions, 3 constraints, advertisedAddresses, lastMaintenance with a
+// long description, networking status, and the gardener identity block.
+func makeShootStatus(idx int) corev1beta1.ShootStatus {
+	now := time.Now()
+	timestamp := metav1.Time{Time: now}
+
+	conditions := []corev1beta1.Condition{
+		newCondition("APIServerAvailable", "HealthzRequestSucceeded",
+			"API server /healthz endpoint responded with success status code.", timestamp),
+		newCondition("ControlPlaneHealthy", "ControlPlaneRunning",
+			"All control plane components are healthy.", timestamp),
+		newCondition("ObservabilityComponentsHealthy", "ObservabilityComponentsRunning",
+			"All observability components are healthy.", timestamp),
+		newCondition("EveryNodeReady", "EveryNodeReady",
+			"All nodes are ready.", timestamp),
+		newCondition("SystemComponentsHealthy", "SystemComponentsRunning",
+			"All system components are healthy.", timestamp),
+	}
+	constraints := []corev1beta1.Condition{
+		newCondition("UsesUnifiedHTTPProxyPort", "ShootUsesUnifiedHTTPProxyPort",
+			"Shoot uses http-proxy port 8443 for VPN", timestamp),
+		newCondition("HibernationPossible", "NoProblematicWebhooks",
+			"All webhooks are properly configured.", timestamp),
+		newCondition("MaintenancePreconditionsSatisfied", "NoProblematicWebhooks",
+			"All webhooks are properly configured.", timestamp),
+	}
+
+	advertisedAddresses := []corev1beta1.ShootAdvertisedAddress{
+		{Name: "external", URL: fmt.Sprintf("https://api.shoot-%06d.bench.example.invalid", idx)},
+		{Name: "wildcard-tls-seed-bound", URL: fmt.Sprintf("https://api-shoot-%06d.ingress.bench.example.invalid", idx)},
+		{Name: "internal", URL: fmt.Sprintf("https://api.shoot-%06d.internal.bench.example.invalid", idx)},
+		{Name: "service-account-issuer", URL: fmt.Sprintf("https://api.shoot-%06d.internal.bench.example.invalid", idx)},
+		{
+			Name: "ingress/oauth2-ingress/0/0",
+			URL:  fmt.Sprintf("https://plutono-shoot-%06d.ingress.bench.example.invalid", idx),
+		},
+	}
+
+	return corev1beta1.ShootStatus{
+		Conditions:  conditions,
+		Constraints: constraints,
+		Gardener: corev1beta1.Gardener{
+			ID:      "bench-gardenlet-id",
+			Name:    "gardenlet-bench",
+			Version: "v1.0.0-bench",
+		},
+		IsHibernated:        false,
+		LastOperation:       makeLastOperation(),
+		LastErrors:          makeLastErrors(),
+		ObservedGeneration:  int64(1000 + idx),
+		SeedName:            ptr.To(fmt.Sprintf("bench-seed-%d", idx%20)),
+		TechnicalID:         fmt.Sprintf("shoot--bench--%06d", idx),
+		UID:                 types.UID(fmt.Sprintf("00000000-0000-0000-0000-%012d", idx)),
+		ClusterIdentity:     ptr.To(fmt.Sprintf("shoot--bench--shoot-%06d-bench-landscape", idx)),
+		AdvertisedAddresses: advertisedAddresses,
+		Credentials: &corev1beta1.ShootCredentials{
+			Rotation: &corev1beta1.ShootCredentialsRotation{},
+		},
+		LastHibernationTriggerTime: &metav1.Time{Time: now.Add(-12 * time.Hour)},
+		LastMaintenance: &corev1beta1.LastMaintenance{
+			Description: strings.Repeat(
+				`Worker pool updated machine image "gardenlinux" from "2150.3.0" to "2150.4.0". `,
+				4),
+			TriggeredTime: metav1.Time{Time: now.Add(-8 * time.Hour)},
+			State:         corev1beta1.LastOperationStateSucceeded,
+		},
+		Networking: &corev1beta1.NetworkingStatus{
+			EgressCIDRs: []string{"10.0.0.0/16"},
+			Nodes:       []string{"10.0.0.0/16"},
+			Pods:        []string{"100.64.0.0/12"},
+			Services:    []string{"100.104.0.0/13"},
+		},
+	}
+}
+
+func makeLastOperation() *corev1beta1.LastOperation {
+	return &corev1beta1.LastOperation{
+		Type:           corev1beta1.LastOperationTypeReconcile,
+		State:          corev1beta1.LastOperationStateSucceeded,
+		Progress:       100,
+		Description:    "Shoot cluster has been successfully reconciled.",
+		LastUpdateTime: metav1.Time{Time: time.Now()},
+	}
+}
+
+func makeLastErrors() []corev1beta1.LastError {
+	// Empty in healthy shoots, but the real type is small enough that we
+	// model the empty slice case explicitly to match the field's typical
+	// presence rather than nil.
+	return nil
+}
+
+func newCondition(condType, reason, message string, timestamp metav1.Time) corev1beta1.Condition {
+	return corev1beta1.Condition{
+		Type:               corev1beta1.ConditionType(condType),
+		Status:             corev1beta1.ConditionTrue,
+		LastTransitionTime: timestamp,
+		LastUpdateTime:     timestamp,
+		Reason:             reason,
+		Message:            message,
+	}
+}
+
+func intOrStringPtr(value int) *intstr.IntOrString {
+	x := intstr.FromInt(value)
+	return &x
+}
+
+// shootGVR is the GroupVersionResource used when driving updates through the
+// fake clientset's tracker. Direct typed Update calls are expensive; using the
+// tracker keeps the churn loop hot path lean.
+var shootGVR = schema.GroupVersionResource{
+	Group:    "core.gardener.cloud",
+	Version:  "v1beta1",
+	Resource: "shoots",
+}
+
+// memSnapshot captures heap state after forcing GC twice. Two GCs because the
+// first frees finalizable objects and the second is the one that gives a
+// stable read.
+func memSnapshot() runtime.MemStats {
+	runtime.GC()
+	runtime.GC()
+	var stats runtime.MemStats
+	runtime.ReadMemStats(&stats)
+	return stats
+}
+
+func reportMem(b *testing.B, label string, before, after runtime.MemStats) {
+	b.Helper()
+	const bytesPerMiB = float64(1 << 20)
+	b.ReportMetric(float64(after.HeapAlloc-before.HeapAlloc)/bytesPerMiB, label+"_heap_MiB")
+	b.ReportMetric(float64(after.HeapInuse-before.HeapInuse)/bytesPerMiB, label+"_inuse_MiB")
+	b.ReportMetric(float64(after.Mallocs-before.Mallocs), label+"_mallocs")
+	// NumGC is a counter of completed GC cycles. memSnapshot forces two GCs
+	// before sampling, so the delta between baseline and post-load shows GC
+	// pressure caused by the load itself rather than by sampling.
+	b.ReportMetric(float64(after.NumGC-before.NumGC), label+"_gc_cycles")
+}
+
+// diffMiB returns (current - baseline) in MiB as a signed float, so callers
+// don't underflow when GC has shrunk the heap below the baseline between
+// samples.
+func diffMiB(current, baseline uint64) float64 {
+	return (float64(current) - float64(baseline)) / float64(1<<20)
+}

--- a/receiver/gardenerreceiver/bench_scale_test.go
+++ b/receiver/gardenerreceiver/bench_scale_test.go
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build bench
+
+package gardenerreceiver
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"testing"
+
+	gardenerfake "github.com/gardener/gardener/pkg/client/core/clientset/versioned/fake"
+	gardenerinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
+	apiruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/cache"
+)
+
+// BenchmarkScale_ShootCache populates N shoots, lets the informer cache fill,
+// and reports the steady-state heap with and without transformShoot.
+//
+// Run as:
+//
+//	go test -tags=bench -bench=BenchmarkScale -benchmem -run=^$ \
+//	    -benchtime=1x -count=5
+//
+// The 1x + count=5 pattern is intentional: we want independent samples of the
+// steady-state footprint, not N iterations of allocate-and-free. The diff
+// between with_transform and no_transform is the value of the optimization.
+func BenchmarkScale_ShootCache(b *testing.B) {
+	for _, shootCount := range []int{100, 1_000, 10_000, 50_000} {
+		b.Run(fmt.Sprintf("shoots=%d/with_transform", shootCount), func(b *testing.B) {
+			runScale(b, shootCount, true)
+		})
+		b.Run(fmt.Sprintf("shoots=%d/no_transform", shootCount), func(b *testing.B) {
+			runScale(b, shootCount, false)
+		})
+	}
+}
+
+func runScale(b *testing.B, shootCount int, withTransform bool) {
+	b.ReportAllocs()
+
+	initialShoots := make([]apiruntime.Object, 0, shootCount)
+	for idx := 0; idx < shootCount; idx++ {
+		initialShoots = append(initialShoots, makeShoot(idx))
+	}
+	gardenClient := gardenerfake.NewSimpleClientset(initialShoots...)
+
+	var opts []gardenerinformers.SharedInformerOption
+	if withTransform {
+		opts = append(opts, gardenerinformers.WithTransform(transformShoot))
+	}
+	shootFactory := gardenerinformers.NewSharedInformerFactoryWithOptions(gardenClient, 0, opts...)
+	shootInformer := shootFactory.Core().V1beta1().Shoots().Informer()
+
+	beforeFill := memSnapshot()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	shootFactory.Start(ctx.Done())
+	if !cache.WaitForCacheSync(ctx.Done(), shootInformer.HasSynced) {
+		b.Fatal("informer cache failed to sync")
+	}
+
+	// Drop the source slice so it doesn't dominate the post-sync heap.
+	initialShoots = nil
+
+	afterFill := memSnapshot()
+	reportMem(b, "steady", beforeFill, afterFill)
+
+	// Keep the cache alive across the measurement so GC doesn't free it.
+	runtime.KeepAlive(shootInformer)
+}

--- a/receiver/gardenerreceiver/receiver.go
+++ b/receiver/gardenerreceiver/receiver.go
@@ -120,6 +120,7 @@ func (r *gardenerReceiver) Start(_ context.Context, _ component.Host) error {
 			r.gardenerClient,
 			r.config.SyncPeriod,
 			gardenerinformers.WithNamespace(r.config.Namespace),
+			gardenerinformers.WithTransform(transformShoot),
 		)
 
 		// Set up Shoot informer
@@ -141,6 +142,7 @@ func (r *gardenerReceiver) Start(_ context.Context, _ component.Host) error {
 			r.gardenerClient,
 			r.config.SyncPeriod,
 			gardenerinformers.WithNamespace(r.config.Namespace),
+			gardenerinformers.WithTransform(transformSecretBinding),
 		)
 		r.secretBindingInformer = bindingFactory.Core().V1beta1().SecretBindings().Informer()
 		bindingFactory.Start(ctx.Done())
@@ -149,6 +151,7 @@ func (r *gardenerReceiver) Start(_ context.Context, _ component.Host) error {
 			r.securityClient,
 			r.config.SyncPeriod,
 			securityinformers.WithNamespace(r.config.Namespace),
+			securityinformers.WithTransform(transformCredentialsBinding),
 		)
 		r.credentialsBindingInformer = securityFactory.Security().V1alpha1().CredentialsBindings().Informer()
 		securityFactory.Start(ctx.Done())
@@ -163,7 +166,11 @@ func (r *gardenerReceiver) Start(_ context.Context, _ component.Host) error {
 	if r.config.HasSeedResource() || r.config.HasProjectResource() {
 		// Seeds and projects are both cluster-scoped resources in the same API group;
 		// share a single factory to avoid duplicate list/watch connections.
-		clusterScopedFactory := gardenerinformers.NewSharedInformerFactory(r.gardenerClient, r.config.SyncPeriod)
+		clusterScopedFactory := gardenerinformers.NewSharedInformerFactoryWithOptions(
+			r.gardenerClient,
+			r.config.SyncPeriod,
+			gardenerinformers.WithTransform(transformCoreClusterScoped),
+		)
 
 		if r.config.HasSeedResource() {
 			r.seedInformer = clusterScopedFactory.Core().V1beta1().Seeds().Informer()
@@ -193,7 +200,11 @@ func (r *gardenerReceiver) Start(_ context.Context, _ component.Host) error {
 	}
 
 	if r.config.HasManagedSeedResource() || r.config.HasGardenletResource() {
-		seedMgmtFactory := seedmanagementinformers.NewSharedInformerFactory(r.seedMgmtClient, r.config.SyncPeriod)
+		seedMgmtFactory := seedmanagementinformers.NewSharedInformerFactoryWithOptions(
+			r.seedMgmtClient,
+			r.config.SyncPeriod,
+			seedmanagementinformers.WithTransform(transformSeedManagement),
+		)
 
 		if r.config.HasManagedSeedResource() {
 			r.managedSeedInformer = seedMgmtFactory.Seedmanagement().V1alpha1().ManagedSeeds().Informer()

--- a/receiver/gardenerreceiver/transform.go
+++ b/receiver/gardenerreceiver/transform.go
@@ -1,0 +1,248 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gardenerreceiver
+
+import (
+	corev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
+	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// The transform functions below are registered via SharedInformerFactory's
+// WithTransform option and are invoked exactly once per object, before it is
+// inserted into the informer cache. That contract makes in-place mutation safe:
+// no consumer can observe the object until the transform returns.
+
+func transformShoot(obj any) (any, error) {
+	shoot, ok := obj.(*corev1beta1.Shoot)
+	if !ok {
+		return obj, nil
+	}
+
+	shoot.ManagedFields = nil
+	shoot.Annotations = nil
+	shoot.Finalizers = nil
+	shoot.OwnerReferences = nil
+
+	// Spec.Provider: keep Type, Region, Workers (partially)
+	shoot.Spec.Provider.InfrastructureConfig = nil
+	shoot.Spec.Provider.ControlPlaneConfig = nil
+	shoot.Spec.Provider.WorkersSettings = nil
+
+	for i := range shoot.Spec.Provider.Workers {
+		w := &shoot.Spec.Provider.Workers[i]
+		w.CABundle = nil
+		w.Kubernetes = nil
+		w.MaxSurge = nil
+		w.MaxUnavailable = nil
+		w.ProviderConfig = nil
+		w.Volume = nil
+		w.DataVolumes = nil
+		w.KubeletDataVolumeName = nil
+		w.SystemComponents = nil
+		w.MachineControllerManagerSettings = nil
+		w.Sysctls = nil
+		w.ClusterAutoscaler = nil
+		w.Priority = nil
+		w.UpdateStrategy = nil
+		w.ControlPlane = nil
+	}
+
+	shoot.Spec.Networking = nil
+	shoot.Spec.Resources = nil
+	shoot.Spec.Tolerations = nil
+	shoot.Spec.SystemComponents = nil
+	shoot.Spec.CloudProfile = nil
+	shoot.Spec.CloudProfileName = nil //nolint:staticcheck // SA1019
+	shoot.Spec.ExposureClassName = nil
+	shoot.Spec.SchedulerName = nil
+
+	if shoot.Spec.Kubernetes.KubeAPIServer != nil {
+		kas := shoot.Spec.Kubernetes.KubeAPIServer
+		kas.ServiceAccountConfig = nil
+		kas.Requests = nil
+		kas.WatchCacheSizes = nil
+		kas.Logging = nil
+		kas.DefaultNotReadyTolerationSeconds = nil
+		kas.DefaultUnreachableTolerationSeconds = nil
+		kas.EventTTL = nil
+		kas.EncryptionConfig = nil
+		kas.StructuredAuthentication = nil
+		kas.StructuredAuthorization = nil
+		kas.Autoscaling = nil
+		kas.EnableAnonymousAuthentication = nil //nolint:staticcheck // SA1019
+		kas.RuntimeConfig = nil
+		kas.APIAudiences = nil
+	}
+
+	shoot.Status.AdvertisedAddresses = nil
+	shoot.Status.ClusterIdentity = nil
+	shoot.Status.Credentials = nil
+	shoot.Status.EncryptedResources = nil //nolint:staticcheck // SA1019
+	shoot.Status.ObservedGeneration = 0
+	shoot.Status.RetryCycleStartTime = nil
+	shoot.Status.SeedName = nil
+	shoot.Status.MigrationStartTime = nil
+	shoot.Status.LastHibernationTriggerTime = nil
+	shoot.Status.LastMaintenance = nil
+	shoot.Status.Networking = nil
+
+	if shoot.Status.LastOperation != nil {
+		shoot.Status.LastOperation.Description = ""
+		shoot.Status.LastOperation.LastUpdateTime = metav1.Time{}
+	}
+	for i := range shoot.Status.LastErrors {
+		shoot.Status.LastErrors[i].Description = ""
+		shoot.Status.LastErrors[i].TaskID = nil
+	}
+
+	return shoot, nil
+}
+
+func transformSeed(obj any) (any, error) {
+	seed, ok := obj.(*corev1beta1.Seed)
+	if !ok {
+		return obj, nil
+	}
+
+	seed.ManagedFields = nil
+	seed.Annotations = nil
+	seed.Finalizers = nil
+	seed.OwnerReferences = nil
+
+	seed.Spec.Backup = nil
+	seed.Spec.DNS = corev1beta1.SeedDNS{}
+	seed.Spec.Networks = corev1beta1.SeedNetworks{}
+	seed.Spec.Provider.ProviderConfig = nil
+	seed.Spec.Provider.Zones = nil
+	seed.Spec.Ingress = nil
+	seed.Spec.Volume = nil
+	seed.Spec.AccessRestrictions = nil
+	seed.Spec.Extensions = nil
+	seed.Spec.Resources = nil
+
+	seed.Status.Gardener = nil
+	seed.Status.ObservedGeneration = 0
+	seed.Status.ClusterIdentity = nil
+	seed.Status.ClientCertificateExpirationTimestamp = nil
+
+	return seed, nil
+}
+
+func transformProject(obj any) (any, error) {
+	project, ok := obj.(*corev1beta1.Project)
+	if !ok {
+		return obj, nil
+	}
+
+	project.ManagedFields = nil
+	project.Finalizers = nil
+	project.OwnerReferences = nil
+
+	project.Spec.Description = nil
+	project.Spec.Purpose = nil
+	project.Spec.CreatedBy = nil
+	project.Spec.Tolerations = nil
+
+	for i := range project.Spec.Members {
+		project.Spec.Members[i] = corev1beta1.ProjectMember{
+			Subject: rbacv1.Subject{Kind: project.Spec.Members[i].Kind},
+		}
+	}
+
+	project.Status.ObservedGeneration = 0
+	project.Status.StaleSinceTimestamp = nil
+	project.Status.StaleAutoDeleteTimestamp = nil
+	project.Status.LastActivityTimestamp = nil
+
+	return project, nil
+}
+
+func transformSecretBinding(obj any) (any, error) {
+	sb, ok := obj.(*corev1beta1.SecretBinding) //nolint:staticcheck // SA1019
+	if !ok {
+		return obj, nil
+	}
+
+	sb.ManagedFields = nil
+	sb.Annotations = nil
+	sb.Finalizers = nil
+	sb.OwnerReferences = nil
+	sb.Provider = nil
+	sb.Quotas = nil
+
+	return sb, nil
+}
+
+func transformCredentialsBinding(obj any) (any, error) {
+	cb, ok := obj.(*securityv1alpha1.CredentialsBinding)
+	if !ok {
+		return obj, nil
+	}
+
+	cb.ManagedFields = nil
+	cb.Annotations = nil
+	cb.Finalizers = nil
+	cb.OwnerReferences = nil
+	cb.Provider = securityv1alpha1.CredentialsBindingProvider{}
+	cb.Quotas = nil
+
+	return cb, nil
+}
+
+func transformManagedSeed(obj any) (any, error) {
+	ms, ok := obj.(*seedmanagementv1alpha1.ManagedSeed)
+	if !ok {
+		return obj, nil
+	}
+
+	ms.ManagedFields = nil
+	ms.Annotations = nil
+	ms.Finalizers = nil
+	ms.OwnerReferences = nil
+	ms.Spec.Gardenlet = seedmanagementv1alpha1.GardenletConfig{}
+	ms.Status = seedmanagementv1alpha1.ManagedSeedStatus{}
+
+	return ms, nil
+}
+
+func transformGardenlet(obj any) (any, error) {
+	gl, ok := obj.(*seedmanagementv1alpha1.Gardenlet)
+	if !ok {
+		return obj, nil
+	}
+
+	gl.ManagedFields = nil
+	gl.Annotations = nil
+	gl.Finalizers = nil
+	gl.OwnerReferences = nil
+	gl.Spec = seedmanagementv1alpha1.GardenletSpec{}
+
+	return gl, nil
+}
+
+func transformCoreClusterScoped(obj any) (any, error) {
+	switch obj.(type) {
+	case *corev1beta1.Seed:
+		return transformSeed(obj)
+	case *corev1beta1.Project:
+		return transformProject(obj)
+	default:
+		return obj, nil
+	}
+}
+
+func transformSeedManagement(obj any) (any, error) {
+	switch obj.(type) {
+	case *seedmanagementv1alpha1.ManagedSeed:
+		return transformManagedSeed(obj)
+	case *seedmanagementv1alpha1.Gardenlet:
+		return transformGardenlet(obj)
+	default:
+		return obj, nil
+	}
+}

--- a/receiver/gardenerreceiver/transform.go
+++ b/receiver/gardenerreceiver/transform.go
@@ -6,16 +6,39 @@ package gardenerreceiver
 
 import (
 	corev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	corev1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	projectAnnotationCostObject     = "billing.gardener.cloud/costObject"
+	projectAnnotationCostObjectType = "billing.gardener.cloud/costObjectType"
+)
+
 // The transform functions below are registered via SharedInformerFactory's
 // WithTransform option and are invoked exactly once per object, before it is
 // inserted into the informer cache. That contract makes in-place mutation safe:
 // no consumer can observe the object until the transform returns.
+
+func retainStringMapKeys(m map[string]string, keys ...string) map[string]string {
+	if len(m) == 0 {
+		return nil
+	}
+
+	retained := make(map[string]string, len(keys))
+	for _, key := range keys {
+		if value, ok := m[key]; ok {
+			retained[key] = value
+		}
+	}
+	if len(retained) == 0 {
+		return nil
+	}
+	return retained
+}
 
 func transformShoot(obj any) (any, error) {
 	shoot, ok := obj.(*corev1beta1.Shoot)
@@ -24,6 +47,7 @@ func transformShoot(obj any) (any, error) {
 	}
 
 	shoot.ManagedFields = nil
+	shoot.Labels = retainStringMapKeys(shoot.Labels, corev1beta1constants.ShootStatus)
 	shoot.Annotations = nil
 	shoot.Finalizers = nil
 	shoot.OwnerReferences = nil
@@ -110,6 +134,7 @@ func transformSeed(obj any) (any, error) {
 	}
 
 	seed.ManagedFields = nil
+	seed.Labels = nil
 	seed.Annotations = nil
 	seed.Finalizers = nil
 	seed.OwnerReferences = nil
@@ -140,6 +165,8 @@ func transformProject(obj any) (any, error) {
 	}
 
 	project.ManagedFields = nil
+	project.Labels = nil
+	project.Annotations = retainStringMapKeys(project.Annotations, projectAnnotationCostObject, projectAnnotationCostObjectType)
 	project.Finalizers = nil
 	project.OwnerReferences = nil
 
@@ -169,6 +196,7 @@ func transformSecretBinding(obj any) (any, error) {
 	}
 
 	sb.ManagedFields = nil
+	sb.Labels = nil
 	sb.Annotations = nil
 	sb.Finalizers = nil
 	sb.OwnerReferences = nil
@@ -185,6 +213,7 @@ func transformCredentialsBinding(obj any) (any, error) {
 	}
 
 	cb.ManagedFields = nil
+	cb.Labels = nil
 	cb.Annotations = nil
 	cb.Finalizers = nil
 	cb.OwnerReferences = nil
@@ -201,6 +230,7 @@ func transformManagedSeed(obj any) (any, error) {
 	}
 
 	ms.ManagedFields = nil
+	ms.Labels = nil
 	ms.Annotations = nil
 	ms.Finalizers = nil
 	ms.OwnerReferences = nil
@@ -217,6 +247,7 @@ func transformGardenlet(obj any) (any, error) {
 	}
 
 	gl.ManagedFields = nil
+	gl.Labels = nil
 	gl.Annotations = nil
 	gl.Finalizers = nil
 	gl.OwnerReferences = nil

--- a/receiver/gardenerreceiver/transform.go
+++ b/receiver/gardenerreceiver/transform.go
@@ -20,8 +20,13 @@ const (
 
 // The transform functions below are registered via SharedInformerFactory's
 // WithTransform option and are invoked exactly once per object, before it is
-// inserted into the informer cache. That contract makes in-place mutation safe:
-// no consumer can observe the object until the transform returns.
+// inserted into the informer cache.
+//
+// Each transform constructs a fresh object and copies only the retained
+// fields. The original is dropped on return — its sub-objects become
+// unreachable and are reclaimed by the next GC cycle. This whitelist style
+// makes the contract explicit: a new field upstream is excluded by default
+// rather than silently retained.
 
 func retainStringMapKeys(m map[string]string, keys ...string) map[string]string {
 	if len(m) == 0 {
@@ -40,220 +45,259 @@ func retainStringMapKeys(m map[string]string, keys ...string) map[string]string 
 	return retained
 }
 
+// retainObjectMeta produces a new ObjectMeta carrying only the fields that
+// downstream metric collectors read. ManagedFields, Annotations, Finalizers,
+// OwnerReferences and Labels are intentionally dropped; callers that need
+// (filtered) Labels or Annotations populate them themselves.
+func retainObjectMeta(meta metav1.ObjectMeta) metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		Name:              meta.Name,
+		Namespace:         meta.Namespace,
+		UID:               meta.UID,
+		ResourceVersion:   meta.ResourceVersion,
+		Generation:        meta.Generation,
+		CreationTimestamp: meta.CreationTimestamp,
+	}
+}
+
 func transformShoot(obj any) (any, error) {
-	shoot, ok := obj.(*corev1beta1.Shoot)
+	src, ok := obj.(*corev1beta1.Shoot)
 	if !ok {
 		return obj, nil
 	}
 
-	shoot.ManagedFields = nil
-	shoot.Labels = retainStringMapKeys(shoot.Labels, corev1beta1constants.ShootStatus)
-	shoot.Annotations = nil
-	shoot.Finalizers = nil
-	shoot.OwnerReferences = nil
+	dst := &corev1beta1.Shoot{
+		TypeMeta:   src.TypeMeta,
+		ObjectMeta: retainObjectMeta(src.ObjectMeta),
+	}
+	dst.Labels = retainStringMapKeys(src.Labels, corev1beta1constants.ShootStatus)
 
-	// Spec.Provider: keep Type, Region, Workers (partially)
-	shoot.Spec.Provider.InfrastructureConfig = nil
-	shoot.Spec.Provider.ControlPlaneConfig = nil
-	shoot.Spec.Provider.WorkersSettings = nil
-
-	for i := range shoot.Spec.Provider.Workers {
-		w := &shoot.Spec.Provider.Workers[i]
-		w.CABundle = nil
-		w.Kubernetes = nil
-		w.MaxSurge = nil
-		w.MaxUnavailable = nil
-		w.ProviderConfig = nil
-		w.Volume = nil
-		w.DataVolumes = nil
-		w.KubeletDataVolumeName = nil
-		w.SystemComponents = nil
-		w.MachineControllerManagerSettings = nil
-		w.Sysctls = nil
-		w.ClusterAutoscaler = nil
-		w.Priority = nil
-		w.UpdateStrategy = nil
-		w.ControlPlane = nil
+	dst.Spec = corev1beta1.ShootSpec{
+		Addons:                 src.Spec.Addons,
+		ControlPlane:           src.Spec.ControlPlane,
+		CredentialsBindingName: src.Spec.CredentialsBindingName,
+		DNS:                    src.Spec.DNS,
+		Extensions:             src.Spec.Extensions,
+		Hibernation:            src.Spec.Hibernation,
+		Kubernetes:             retainShootKubernetes(src.Spec.Kubernetes),
+		Maintenance:            src.Spec.Maintenance,
+		Provider:               retainShootProvider(src.Spec.Provider),
+		Purpose:                src.Spec.Purpose,
+		Region:                 src.Spec.Region,
+		SecretBindingName:      src.Spec.SecretBindingName, //nolint:staticcheck // SA1019
+		SeedName:               src.Spec.SeedName,
 	}
 
-	shoot.Spec.Networking = nil
-	shoot.Spec.Resources = nil
-	shoot.Spec.Tolerations = nil
-	shoot.Spec.SystemComponents = nil
-	shoot.Spec.CloudProfile = nil
-	shoot.Spec.CloudProfileName = nil //nolint:staticcheck // SA1019
-	shoot.Spec.ExposureClassName = nil
-	shoot.Spec.SchedulerName = nil
-
-	if shoot.Spec.Kubernetes.KubeAPIServer != nil {
-		kas := shoot.Spec.Kubernetes.KubeAPIServer
-		kas.ServiceAccountConfig = nil
-		kas.Requests = nil
-		kas.WatchCacheSizes = nil
-		kas.Logging = nil
-		kas.DefaultNotReadyTolerationSeconds = nil
-		kas.DefaultUnreachableTolerationSeconds = nil
-		kas.EventTTL = nil
-		kas.EncryptionConfig = nil
-		kas.StructuredAuthentication = nil
-		kas.StructuredAuthorization = nil
-		kas.Autoscaling = nil
-		kas.EnableAnonymousAuthentication = nil //nolint:staticcheck // SA1019
-		kas.RuntimeConfig = nil
-		kas.APIAudiences = nil
+	dst.Status = corev1beta1.ShootStatus{
+		Conditions:    src.Status.Conditions,
+		Constraints:   src.Status.Constraints,
+		Gardener:      src.Status.Gardener,
+		IsHibernated:  src.Status.IsHibernated,
+		LastErrors:    retainLastErrors(src.Status.LastErrors),
+		LastOperation: retainLastOperation(src.Status.LastOperation),
+		TechnicalID:   src.Status.TechnicalID,
+		UID:           src.Status.UID,
 	}
 
-	shoot.Status.AdvertisedAddresses = nil
-	shoot.Status.ClusterIdentity = nil
-	shoot.Status.Credentials = nil
-	shoot.Status.EncryptedResources = nil //nolint:staticcheck // SA1019
-	shoot.Status.ObservedGeneration = 0
-	shoot.Status.RetryCycleStartTime = nil
-	shoot.Status.SeedName = nil
-	shoot.Status.MigrationStartTime = nil
-	shoot.Status.LastHibernationTriggerTime = nil
-	shoot.Status.LastMaintenance = nil
-	shoot.Status.Networking = nil
-
-	if shoot.Status.LastOperation != nil {
-		shoot.Status.LastOperation.Description = ""
-		shoot.Status.LastOperation.LastUpdateTime = metav1.Time{}
-	}
-	for i := range shoot.Status.LastErrors {
-		shoot.Status.LastErrors[i].Description = ""
-		shoot.Status.LastErrors[i].TaskID = nil
-	}
-
-	return shoot, nil
+	return dst, nil
 }
 
-func transformSeed(obj any) (any, error) {
-	seed, ok := obj.(*corev1beta1.Seed)
-	if !ok {
-		return obj, nil
+// retainShootProvider keeps Type, Workers (selectively), and drops the heavy
+// InfrastructureConfig / ControlPlaneConfig / WorkersSettings raw extensions.
+func retainShootProvider(src corev1beta1.Provider) corev1beta1.Provider {
+	dst := corev1beta1.Provider{
+		Type: src.Type,
+	}
+	if src.Workers == nil {
+		return dst
 	}
 
-	seed.ManagedFields = nil
-	seed.Labels = nil
-	seed.Annotations = nil
-	seed.Finalizers = nil
-	seed.OwnerReferences = nil
-
-	seed.Spec.Backup = nil
-	seed.Spec.DNS = corev1beta1.SeedDNS{}
-	seed.Spec.Networks = corev1beta1.SeedNetworks{}
-	seed.Spec.Provider.ProviderConfig = nil
-	seed.Spec.Provider.Zones = nil
-	seed.Spec.Ingress = nil
-	seed.Spec.Volume = nil
-	seed.Spec.AccessRestrictions = nil
-	seed.Spec.Extensions = nil
-	seed.Spec.Resources = nil
-
-	seed.Status.Gardener = nil
-	seed.Status.ObservedGeneration = 0
-	seed.Status.ClusterIdentity = nil
-	seed.Status.ClientCertificateExpirationTimestamp = nil
-
-	return seed, nil
+	dst.Workers = make([]corev1beta1.Worker, len(src.Workers))
+	for i := range src.Workers {
+		s := &src.Workers[i]
+		dst.Workers[i] = corev1beta1.Worker{
+			Annotations: s.Annotations,
+			CRI:         s.CRI,
+			Labels:      s.Labels,
+			Machine:     s.Machine,
+			Maximum:     s.Maximum,
+			Minimum:     s.Minimum,
+			Name:        s.Name,
+			Taints:      s.Taints,
+			Zones:       s.Zones,
+		}
+	}
+	return dst
 }
 
-func transformProject(obj any) (any, error) {
-	project, ok := obj.(*corev1beta1.Project)
-	if !ok {
-		return obj, nil
+// retainShootKubernetes preserves the version and small per-component config
+// blocks, but trims KubeAPIServer to the fields that drive metrics
+// (admission plugins, audit policy presence, OIDC presence, feature gates
+// inside KubernetesConfig).
+func retainShootKubernetes(src corev1beta1.Kubernetes) corev1beta1.Kubernetes {
+	dst := corev1beta1.Kubernetes{
+		Version:               src.Version,
+		KubeControllerManager: src.KubeControllerManager,
+		KubeScheduler:         src.KubeScheduler,
+		Kubelet:               src.Kubelet,
+		KubeProxy:             src.KubeProxy,
 	}
 
-	project.ManagedFields = nil
-	project.Labels = nil
-	project.Annotations = retainStringMapKeys(project.Annotations, projectAnnotationCostObject, projectAnnotationCostObjectType)
-	project.Finalizers = nil
-	project.OwnerReferences = nil
-
-	project.Spec.Description = nil
-	project.Spec.Purpose = nil
-	project.Spec.CreatedBy = nil
-	project.Spec.Tolerations = nil
-
-	for i := range project.Spec.Members {
-		project.Spec.Members[i] = corev1beta1.ProjectMember{
-			Subject: rbacv1.Subject{Kind: project.Spec.Members[i].Kind},
+	if src.KubeAPIServer != nil {
+		s := src.KubeAPIServer
+		dst.KubeAPIServer = &corev1beta1.KubeAPIServerConfig{
+			KubernetesConfig: s.KubernetesConfig,
+			AdmissionPlugins: s.AdmissionPlugins,
+			AuditConfig:      s.AuditConfig,
+			OIDCConfig:       s.OIDCConfig, //nolint:staticcheck // SA1019
 		}
 	}
 
-	project.Status.ObservedGeneration = 0
-	project.Status.StaleSinceTimestamp = nil
-	project.Status.StaleAutoDeleteTimestamp = nil
-	project.Status.LastActivityTimestamp = nil
+	return dst
+}
 
-	return project, nil
+// retainLastOperation keeps Type/State/Progress for metric reporting and drops
+// the verbose Description and LastUpdateTime that bloat the cache.
+func retainLastOperation(src *corev1beta1.LastOperation) *corev1beta1.LastOperation {
+	if src == nil {
+		return nil
+	}
+	return &corev1beta1.LastOperation{
+		Type:     src.Type,
+		State:    src.State,
+		Progress: src.Progress,
+	}
+}
+
+// retainLastErrors keeps only Codes — the only field hasUserErrors consumes.
+func retainLastErrors(src []corev1beta1.LastError) []corev1beta1.LastError {
+	if src == nil {
+		return nil
+	}
+	dst := make([]corev1beta1.LastError, len(src))
+	for i := range src {
+		dst[i] = corev1beta1.LastError{
+			Codes: src[i].Codes,
+		}
+	}
+	return dst
+}
+
+func transformSeed(obj any) (any, error) {
+	src, ok := obj.(*corev1beta1.Seed)
+	if !ok {
+		return obj, nil
+	}
+
+	dst := &corev1beta1.Seed{
+		TypeMeta:   src.TypeMeta,
+		ObjectMeta: retainObjectMeta(src.ObjectMeta),
+		Spec: corev1beta1.SeedSpec{
+			Provider: corev1beta1.SeedProvider{
+				Type:   src.Spec.Provider.Type,
+				Region: src.Spec.Provider.Region,
+			},
+			Settings: src.Spec.Settings,
+			Taints:   src.Spec.Taints,
+		},
+		Status: corev1beta1.SeedStatus{
+			Allocatable:       src.Status.Allocatable,
+			Capacity:          src.Status.Capacity,
+			Conditions:        src.Status.Conditions,
+			KubernetesVersion: src.Status.KubernetesVersion,
+			LastOperation:     src.Status.LastOperation,
+		},
+	}
+	return dst, nil
+}
+
+func transformProject(obj any) (any, error) {
+	src, ok := obj.(*corev1beta1.Project)
+	if !ok {
+		return obj, nil
+	}
+
+	dst := &corev1beta1.Project{
+		TypeMeta:   src.TypeMeta,
+		ObjectMeta: retainObjectMeta(src.ObjectMeta),
+		Spec: corev1beta1.ProjectSpec{
+			Namespace: src.Spec.Namespace,
+			Owner:     src.Spec.Owner,
+		},
+		Status: corev1beta1.ProjectStatus{
+			Phase: src.Status.Phase,
+		},
+	}
+	dst.Annotations = retainStringMapKeys(src.Annotations,
+		projectAnnotationCostObject, projectAnnotationCostObjectType)
+
+	if src.Spec.Members != nil {
+		dst.Spec.Members = make([]corev1beta1.ProjectMember, len(src.Spec.Members))
+		for i := range src.Spec.Members {
+			dst.Spec.Members[i] = corev1beta1.ProjectMember{
+				Subject: rbacv1.Subject{Kind: src.Spec.Members[i].Kind},
+			}
+		}
+	}
+
+	return dst, nil
 }
 
 func transformSecretBinding(obj any) (any, error) {
-	sb, ok := obj.(*corev1beta1.SecretBinding) //nolint:staticcheck // SA1019
+	src, ok := obj.(*corev1beta1.SecretBinding) //nolint:staticcheck // SA1019
 	if !ok {
 		return obj, nil
 	}
 
-	sb.ManagedFields = nil
-	sb.Labels = nil
-	sb.Annotations = nil
-	sb.Finalizers = nil
-	sb.OwnerReferences = nil
-	sb.Provider = nil
-	sb.Quotas = nil
-
-	return sb, nil
+	return &corev1beta1.SecretBinding{ //nolint:staticcheck // SA1019
+		TypeMeta:   src.TypeMeta,
+		ObjectMeta: retainObjectMeta(src.ObjectMeta),
+		SecretRef:  src.SecretRef,
+	}, nil
 }
 
 func transformCredentialsBinding(obj any) (any, error) {
-	cb, ok := obj.(*securityv1alpha1.CredentialsBinding)
+	src, ok := obj.(*securityv1alpha1.CredentialsBinding)
 	if !ok {
 		return obj, nil
 	}
 
-	cb.ManagedFields = nil
-	cb.Labels = nil
-	cb.Annotations = nil
-	cb.Finalizers = nil
-	cb.OwnerReferences = nil
-	cb.Provider = securityv1alpha1.CredentialsBindingProvider{}
-	cb.Quotas = nil
-
-	return cb, nil
+	return &securityv1alpha1.CredentialsBinding{
+		TypeMeta:       src.TypeMeta,
+		ObjectMeta:     retainObjectMeta(src.ObjectMeta),
+		CredentialsRef: src.CredentialsRef,
+	}, nil
 }
 
 func transformManagedSeed(obj any) (any, error) {
-	ms, ok := obj.(*seedmanagementv1alpha1.ManagedSeed)
+	src, ok := obj.(*seedmanagementv1alpha1.ManagedSeed)
 	if !ok {
 		return obj, nil
 	}
 
-	ms.ManagedFields = nil
-	ms.Labels = nil
-	ms.Annotations = nil
-	ms.Finalizers = nil
-	ms.OwnerReferences = nil
-	ms.Spec.Gardenlet = seedmanagementv1alpha1.GardenletConfig{}
-	ms.Status = seedmanagementv1alpha1.ManagedSeedStatus{}
-
-	return ms, nil
+	return &seedmanagementv1alpha1.ManagedSeed{
+		TypeMeta:   src.TypeMeta,
+		ObjectMeta: retainObjectMeta(src.ObjectMeta),
+		Spec: seedmanagementv1alpha1.ManagedSeedSpec{
+			Shoot: src.Spec.Shoot,
+		},
+	}, nil
 }
 
 func transformGardenlet(obj any) (any, error) {
-	gl, ok := obj.(*seedmanagementv1alpha1.Gardenlet)
+	src, ok := obj.(*seedmanagementv1alpha1.Gardenlet)
 	if !ok {
 		return obj, nil
 	}
 
-	gl.ManagedFields = nil
-	gl.Labels = nil
-	gl.Annotations = nil
-	gl.Finalizers = nil
-	gl.OwnerReferences = nil
-	gl.Spec = seedmanagementv1alpha1.GardenletSpec{}
-
-	return gl, nil
+	return &seedmanagementv1alpha1.Gardenlet{
+		TypeMeta:   src.TypeMeta,
+		ObjectMeta: retainObjectMeta(src.ObjectMeta),
+		Status: seedmanagementv1alpha1.GardenletStatus{
+			Conditions:         src.Status.Conditions,
+			ObservedGeneration: src.Status.ObservedGeneration,
+		},
+	}, nil
 }
 
 func transformCoreClusterScoped(obj any) (any, error) {

--- a/receiver/gardenerreceiver/transform_test.go
+++ b/receiver/gardenerreceiver/transform_test.go
@@ -1,0 +1,796 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package gardenerreceiver
+
+import (
+	"testing"
+
+	corev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
+	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+)
+
+func TestTransformShoot_RetainsUsedFields(t *testing.T) {
+	shoot := &corev1beta1.Shoot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "my-shoot",
+			Namespace:         "garden-dev",
+			UID:               "abc-123",
+			Labels:            map[string]string{"shoot.gardener.cloud/status": "healthy"},
+			CreationTimestamp: metav1.Now(),
+		},
+		Spec: corev1beta1.ShootSpec{
+			Region: "eu-west-1",
+			Provider: corev1beta1.Provider{
+				Type: "aws",
+				Workers: []corev1beta1.Worker{
+					{
+						Name:    "worker-1",
+						Minimum: 1,
+						Maximum: 3,
+						Machine: corev1beta1.Machine{
+							Type: "m5.large",
+							Image: &corev1beta1.ShootMachineImage{
+								Name:    "gardenlinux",
+								Version: ptr.To("1.0"),
+							},
+							Architecture: ptr.To("amd64"),
+						},
+						CRI: &corev1beta1.CRI{
+							Name: "containerd",
+						},
+						Zones:  []string{"eu-west-1a"},
+						Taints: []corev1.Taint{{Key: "key1"}},
+						Labels: map[string]string{"l": "v"},
+					},
+				},
+			},
+			Kubernetes: corev1beta1.Kubernetes{
+				Version: "1.28.0",
+				KubeAPIServer: &corev1beta1.KubeAPIServerConfig{
+					AuditConfig: &corev1beta1.AuditConfig{},
+					OIDCConfig:  &corev1beta1.OIDCConfig{}, //nolint:staticcheck // SA1019
+					AdmissionPlugins: []corev1beta1.AdmissionPlugin{
+						{Name: "PodSecurity"},
+					},
+				},
+				KubeControllerManager: &corev1beta1.KubeControllerManagerConfig{
+					NodeCIDRMaskSize:              ptr.To[int32](24),
+					HorizontalPodAutoscalerConfig: &corev1beta1.HorizontalPodAutoscalerConfig{},
+				},
+				KubeScheduler: &corev1beta1.KubeSchedulerConfig{},
+				Kubelet:       &corev1beta1.KubeletConfig{PodPIDsLimit: ptr.To[int64](100)},
+				KubeProxy:     &corev1beta1.KubeProxyConfig{},
+			},
+			SeedName: ptr.To("seed-1"),
+			Purpose:  (*corev1beta1.ShootPurpose)(ptr.To("production")),
+			ControlPlane: &corev1beta1.ControlPlane{
+				HighAvailability: &corev1beta1.HighAvailability{
+					FailureTolerance: corev1beta1.FailureTolerance{
+						Type: corev1beta1.FailureToleranceTypeZone,
+					},
+				},
+			},
+			Hibernation: &corev1beta1.Hibernation{
+				Enabled:   ptr.To(true),
+				Schedules: []corev1beta1.HibernationSchedule{{Start: ptr.To("0 17 * * *")}},
+			},
+			Maintenance: &corev1beta1.Maintenance{
+				TimeWindow: &corev1beta1.MaintenanceTimeWindow{Begin: "010000+0000", End: "020000+0000"},
+				AutoUpdate: &corev1beta1.MaintenanceAutoUpdate{KubernetesVersion: true},
+			},
+			Addons: &corev1beta1.Addons{
+				NginxIngress:        &corev1beta1.NginxIngress{Addon: corev1beta1.Addon{Enabled: true}},
+				KubernetesDashboard: &corev1beta1.KubernetesDashboard{Addon: corev1beta1.Addon{Enabled: true}},
+			},
+			DNS:                    &corev1beta1.DNS{Domain: ptr.To("example.com")},
+			Extensions:             []corev1beta1.Extension{{Type: "shoot-dns-service"}},
+			SecretBindingName:      ptr.To("sb-1"), //nolint:staticcheck // SA1019
+			CredentialsBindingName: ptr.To("cb-1"),
+		},
+		Status: corev1beta1.ShootStatus{
+			TechnicalID:  "shoot--dev--my-shoot",
+			IsHibernated: true,
+			LastOperation: &corev1beta1.LastOperation{
+				Type:     corev1beta1.LastOperationTypeReconcile,
+				State:    corev1beta1.LastOperationStateSucceeded,
+				Progress: 100,
+			},
+			Conditions:  []corev1beta1.Condition{{Type: "APIServerAvailable", Status: "True"}},
+			Constraints: []corev1beta1.Condition{{Type: "MaintenancePreconditionsSatisfied", Status: "True"}},
+			LastErrors:  []corev1beta1.LastError{{Description: "err"}},
+			Gardener:    corev1beta1.Gardener{Version: "1.90.0"},
+		},
+	}
+
+	result, err := transformShoot(shoot)
+	require.NoError(t, err)
+	s := result.(*corev1beta1.Shoot)
+
+	assert.Equal(t, "my-shoot", s.Name)
+	assert.Equal(t, "garden-dev", s.Namespace)
+	assert.Equal(t, "healthy", s.Labels["shoot.gardener.cloud/status"])
+	assert.NotEmpty(t, s.CreationTimestamp)
+	assert.Equal(t, "aws", s.Spec.Provider.Type)
+	assert.Equal(t, "eu-west-1", s.Spec.Region)
+	assert.Len(t, s.Spec.Provider.Workers, 1)
+	assert.Equal(t, "worker-1", s.Spec.Provider.Workers[0].Name)
+	assert.Equal(t, int32(1), s.Spec.Provider.Workers[0].Minimum)
+	assert.Equal(t, int32(3), s.Spec.Provider.Workers[0].Maximum)
+	assert.Equal(t, "m5.large", s.Spec.Provider.Workers[0].Machine.Type)
+	assert.NotNil(t, s.Spec.Provider.Workers[0].Machine.Image)
+	assert.NotNil(t, s.Spec.Provider.Workers[0].CRI)
+	assert.Equal(t, []string{"eu-west-1a"}, s.Spec.Provider.Workers[0].Zones)
+	assert.Len(t, s.Spec.Provider.Workers[0].Taints, 1)
+	assert.Equal(t, "1.28.0", s.Spec.Kubernetes.Version)
+	assert.NotNil(t, s.Spec.Kubernetes.KubeAPIServer.AuditConfig)
+	assert.NotNil(t, s.Spec.Kubernetes.KubeAPIServer.OIDCConfig) //nolint:staticcheck // SA1019
+	assert.Len(t, s.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins, 1)
+	assert.NotNil(t, s.Spec.Kubernetes.KubeControllerManager)
+	assert.NotNil(t, s.Spec.Kubernetes.KubeScheduler)
+	assert.NotNil(t, s.Spec.Kubernetes.Kubelet)
+	assert.NotNil(t, s.Spec.Kubernetes.KubeProxy)
+	assert.Equal(t, ptr.To("seed-1"), s.Spec.SeedName)
+	assert.NotNil(t, s.Spec.Purpose)
+	assert.NotNil(t, s.Spec.ControlPlane)
+	assert.NotNil(t, s.Spec.Hibernation)
+	assert.NotNil(t, s.Spec.Maintenance)
+	assert.NotNil(t, s.Spec.Addons)
+	assert.NotNil(t, s.Spec.DNS)
+	assert.Len(t, s.Spec.Extensions, 1)
+	assert.NotNil(t, s.Spec.SecretBindingName) //nolint:staticcheck // SA1019
+	assert.NotNil(t, s.Spec.CredentialsBindingName)
+	assert.Equal(t, "shoot--dev--my-shoot", s.Status.TechnicalID)
+	assert.True(t, s.Status.IsHibernated)
+	assert.NotNil(t, s.Status.LastOperation)
+	assert.Len(t, s.Status.Conditions, 1)
+	assert.Len(t, s.Status.Constraints, 1)
+	assert.Len(t, s.Status.LastErrors, 1)
+	assert.Equal(t, "1.90.0", s.Status.Gardener.Version)
+}
+
+func TestTransformShoot_StripsUnusedFields(t *testing.T) {
+	shoot := &corev1beta1.Shoot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "my-shoot",
+			Namespace:       "garden-dev",
+			ManagedFields:   []metav1.ManagedFieldsEntry{{Manager: "gardener"}},
+			Annotations:     map[string]string{"foo": "bar"},
+			Finalizers:      []string{"gardener"},
+			OwnerReferences: []metav1.OwnerReference{{Name: "owner"}},
+		},
+		Spec: corev1beta1.ShootSpec{
+			Provider: corev1beta1.Provider{
+				Type:                 "aws",
+				InfrastructureConfig: &runtime.RawExtension{Raw: []byte(`{}`)},
+				ControlPlaneConfig:   &runtime.RawExtension{Raw: []byte(`{}`)},
+				WorkersSettings:      &corev1beta1.WorkersSettings{},
+				Workers: []corev1beta1.Worker{
+					{
+						Name:    "worker-1",
+						Minimum: 1,
+						Maximum: 3,
+						Machine: corev1beta1.Machine{Type: "m5.large"},
+						// Fields that should be stripped:
+						CABundle:                         ptr.To("cert"),
+						Kubernetes:                       &corev1beta1.WorkerKubernetes{},
+						MaxSurge:                         &intstr.IntOrString{IntVal: 1},
+						MaxUnavailable:                   &intstr.IntOrString{IntVal: 0},
+						ProviderConfig:                   &runtime.RawExtension{Raw: []byte(`{}`)},
+						Volume:                           &corev1beta1.Volume{VolumeSize: "50Gi"},
+						DataVolumes:                      []corev1beta1.DataVolume{{Name: "dv"}},
+						KubeletDataVolumeName:            ptr.To("dv"),
+						SystemComponents:                 &corev1beta1.WorkerSystemComponents{},
+						MachineControllerManagerSettings: &corev1beta1.MachineControllerManagerSettings{},
+						Sysctls:                          map[string]string{"vm.max_map_count": "262144"},
+						ClusterAutoscaler:                &corev1beta1.ClusterAutoscalerOptions{},
+						Priority:                         ptr.To[int32](1),
+						UpdateStrategy:                   (*corev1beta1.MachineUpdateStrategy)(ptr.To("Rolling")),
+						ControlPlane:                     &corev1beta1.WorkerControlPlane{},
+					},
+				},
+			},
+			Networking:        &corev1beta1.Networking{Type: ptr.To("calico")},
+			Resources:         []corev1beta1.NamedResourceReference{{Name: "res"}},
+			Tolerations:       []corev1beta1.Toleration{{Key: "t"}},
+			SystemComponents:  &corev1beta1.SystemComponents{},
+			CloudProfile:      &corev1beta1.CloudProfileReference{Name: "cp"},
+			CloudProfileName:  ptr.To("cp"), //nolint:staticcheck // SA1019
+			ExposureClassName: ptr.To("exposure"),
+			SchedulerName:     ptr.To("sched"),
+			Kubernetes: corev1beta1.Kubernetes{
+				Version: "1.28.0",
+				KubeAPIServer: &corev1beta1.KubeAPIServerConfig{
+					ServiceAccountConfig:                &corev1beta1.ServiceAccountConfig{},
+					Requests:                            &corev1beta1.APIServerRequests{},
+					WatchCacheSizes:                     &corev1beta1.WatchCacheSizes{},
+					Logging:                             &corev1beta1.APIServerLogging{},
+					DefaultNotReadyTolerationSeconds:    ptr.To[int64](300),
+					DefaultUnreachableTolerationSeconds: ptr.To[int64](300),
+					EventTTL:                            &metav1.Duration{},
+					EncryptionConfig:                    &corev1beta1.EncryptionConfig{},
+					StructuredAuthentication:            &corev1beta1.StructuredAuthentication{},
+					StructuredAuthorization:             &corev1beta1.StructuredAuthorization{},
+					EnableAnonymousAuthentication:       ptr.To(false), //nolint:staticcheck // SA1019
+					RuntimeConfig:                       map[string]bool{"v1": true},
+					APIAudiences:                        []string{"kubernetes"},
+				},
+			},
+		},
+		Status: corev1beta1.ShootStatus{
+			TechnicalID:                "shoot--dev--my-shoot",
+			AdvertisedAddresses:        []corev1beta1.ShootAdvertisedAddress{{Name: "ext"}},
+			ClusterIdentity:            ptr.To("id"),
+			Credentials:                &corev1beta1.ShootCredentials{},
+			EncryptedResources:         []string{"secrets"}, //nolint:staticcheck // SA1019
+			ObservedGeneration:         5,
+			RetryCycleStartTime:        &metav1.Time{},
+			SeedName:                   ptr.To("seed-1"),
+			MigrationStartTime:         &metav1.Time{},
+			LastHibernationTriggerTime: &metav1.Time{},
+			LastMaintenance:            &corev1beta1.LastMaintenance{},
+			Networking:                 &corev1beta1.NetworkingStatus{},
+			LastOperation: &corev1beta1.LastOperation{
+				Type:           corev1beta1.LastOperationTypeReconcile,
+				State:          corev1beta1.LastOperationStateProcessing,
+				Progress:       42,
+				Description:    "long progress description that should be stripped",
+				LastUpdateTime: metav1.Now(),
+			},
+			LastErrors: []corev1beta1.LastError{
+				{
+					Description: "noisy error description that should be stripped",
+					TaskID:      ptr.To("task-1"),
+					Codes:       []corev1beta1.ErrorCode{corev1beta1.ErrorInfraUnauthorized},
+				},
+			},
+		},
+	}
+
+	result, err := transformShoot(shoot)
+	require.NoError(t, err)
+	s := result.(*corev1beta1.Shoot)
+
+	// ObjectMeta stripped
+	assert.Nil(t, s.ManagedFields)
+	assert.Nil(t, s.Annotations)
+	assert.Nil(t, s.Finalizers)
+	assert.Nil(t, s.OwnerReferences)
+
+	// Provider stripped
+	assert.Nil(t, s.Spec.Provider.InfrastructureConfig)
+	assert.Nil(t, s.Spec.Provider.ControlPlaneConfig)
+	assert.Nil(t, s.Spec.Provider.WorkersSettings)
+
+	// Worker sub-fields stripped
+	w := s.Spec.Provider.Workers[0]
+	assert.Nil(t, w.CABundle)
+	assert.Nil(t, w.Kubernetes)
+	assert.Nil(t, w.MaxSurge)
+	assert.Nil(t, w.MaxUnavailable)
+	assert.Nil(t, w.ProviderConfig)
+	assert.Nil(t, w.Volume)
+	assert.Nil(t, w.DataVolumes)
+	assert.Nil(t, w.KubeletDataVolumeName)
+	assert.Nil(t, w.SystemComponents)
+	assert.Nil(t, w.MachineControllerManagerSettings)
+	assert.Nil(t, w.Sysctls)
+	assert.Nil(t, w.ClusterAutoscaler)
+	assert.Nil(t, w.Priority)
+	assert.Nil(t, w.UpdateStrategy)
+	assert.Nil(t, w.ControlPlane)
+
+	// Spec fields stripped
+	assert.Nil(t, s.Spec.Networking)
+	assert.Nil(t, s.Spec.Resources)
+	assert.Nil(t, s.Spec.Tolerations)
+	assert.Nil(t, s.Spec.SystemComponents)
+	assert.Nil(t, s.Spec.CloudProfile)
+	assert.Nil(t, s.Spec.CloudProfileName) //nolint:staticcheck // SA1019
+	assert.Nil(t, s.Spec.ExposureClassName)
+	assert.Nil(t, s.Spec.SchedulerName)
+
+	// KubeAPIServer fields stripped
+	kas := s.Spec.Kubernetes.KubeAPIServer
+	assert.Nil(t, kas.ServiceAccountConfig)
+	assert.Nil(t, kas.Requests)
+	assert.Nil(t, kas.WatchCacheSizes)
+	assert.Nil(t, kas.Logging)
+	assert.Nil(t, kas.DefaultNotReadyTolerationSeconds)
+	assert.Nil(t, kas.DefaultUnreachableTolerationSeconds)
+	assert.Nil(t, kas.EventTTL)
+	assert.Nil(t, kas.EncryptionConfig)
+	assert.Nil(t, kas.StructuredAuthentication)
+	assert.Nil(t, kas.StructuredAuthorization)
+	assert.Nil(t, kas.EnableAnonymousAuthentication) //nolint:staticcheck // SA1019
+	assert.Nil(t, kas.RuntimeConfig)
+	assert.Nil(t, kas.APIAudiences)
+
+	// Status fields stripped
+	assert.Nil(t, s.Status.AdvertisedAddresses)
+	assert.Nil(t, s.Status.ClusterIdentity)
+	assert.Nil(t, s.Status.Credentials)
+	assert.Nil(t, s.Status.EncryptedResources) //nolint:staticcheck // SA1019
+	assert.Equal(t, int64(0), s.Status.ObservedGeneration)
+	assert.Nil(t, s.Status.RetryCycleStartTime)
+	assert.Nil(t, s.Status.SeedName)
+	assert.Nil(t, s.Status.MigrationStartTime)
+	assert.Nil(t, s.Status.LastHibernationTriggerTime)
+	assert.Nil(t, s.Status.LastMaintenance)
+	assert.Nil(t, s.Status.Networking)
+
+	// LastOperation: kept, with verbose fields cleared
+	require.NotNil(t, s.Status.LastOperation)
+	assert.Equal(t, corev1beta1.LastOperationTypeReconcile, s.Status.LastOperation.Type)
+	assert.Equal(t, corev1beta1.LastOperationStateProcessing, s.Status.LastOperation.State)
+	assert.Equal(t, int32(42), s.Status.LastOperation.Progress)
+	assert.Empty(t, s.Status.LastOperation.Description)
+	assert.True(t, s.Status.LastOperation.LastUpdateTime.IsZero())
+
+	// LastErrors: kept (Codes is consumed by hasUserErrors), Description/TaskID cleared
+	require.Len(t, s.Status.LastErrors, 1)
+	assert.Empty(t, s.Status.LastErrors[0].Description)
+	assert.Nil(t, s.Status.LastErrors[0].TaskID)
+	assert.Equal(t, []corev1beta1.ErrorCode{corev1beta1.ErrorInfraUnauthorized}, s.Status.LastErrors[0].Codes)
+}
+
+func TestTransformShoot_Idempotent(t *testing.T) {
+	shoot := &corev1beta1.Shoot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:          "my-shoot",
+			Namespace:     "garden-dev",
+			ManagedFields: []metav1.ManagedFieldsEntry{{Manager: "gardener"}},
+		},
+		Spec: corev1beta1.ShootSpec{
+			Provider:   corev1beta1.Provider{Type: "aws", Workers: []corev1beta1.Worker{{Name: "w"}}},
+			Kubernetes: corev1beta1.Kubernetes{Version: "1.28.0"},
+		},
+	}
+
+	result1, err := transformShoot(shoot)
+	require.NoError(t, err)
+	result2, err := transformShoot(result1)
+	require.NoError(t, err)
+
+	s1 := result1.(*corev1beta1.Shoot)
+	s2 := result2.(*corev1beta1.Shoot)
+	assert.Equal(t, s1.Name, s2.Name)
+	assert.Nil(t, s2.ManagedFields)
+}
+
+func TestTransformShoot_NilSafety(t *testing.T) {
+	shoot := &corev1beta1.Shoot{
+		ObjectMeta: metav1.ObjectMeta{Name: "minimal"},
+		Spec: corev1beta1.ShootSpec{
+			Provider:   corev1beta1.Provider{Type: "aws"},
+			Kubernetes: corev1beta1.Kubernetes{Version: "1.28.0"},
+		},
+	}
+
+	_, err := transformShoot(shoot)
+	require.NoError(t, err)
+}
+
+func TestTransformShoot_UnknownType(t *testing.T) {
+	obj := "not a shoot"
+	result, err := transformShoot(obj)
+	require.NoError(t, err)
+	assert.Equal(t, "not a shoot", result)
+}
+
+func TestTransformSeed_RetainsUsedFields(t *testing.T) {
+	seed := &corev1beta1.Seed{
+		ObjectMeta: metav1.ObjectMeta{Name: "seed-1"},
+		Spec: corev1beta1.SeedSpec{
+			Provider: corev1beta1.SeedProvider{
+				Type:   "aws",
+				Region: "eu-west-1",
+			},
+			Taints: []corev1beta1.SeedTaint{{Key: "seed.gardener.cloud/protected"}},
+			Settings: &corev1beta1.SeedSettings{
+				Scheduling: &corev1beta1.SeedSettingScheduling{Visible: true},
+			},
+		},
+		Status: corev1beta1.SeedStatus{
+			KubernetesVersion: ptr.To("1.28.0"),
+			Capacity:          corev1.ResourceList{"shoots": resource.MustParse("100")},
+			Allocatable:       corev1.ResourceList{"shoots": resource.MustParse("50")},
+			Conditions:        []corev1beta1.Condition{{Type: "GardenletReady", Status: "True"}},
+			LastOperation: &corev1beta1.LastOperation{
+				Type:  corev1beta1.LastOperationTypeReconcile,
+				State: corev1beta1.LastOperationStateSucceeded,
+			},
+		},
+	}
+
+	result, err := transformSeed(seed)
+	require.NoError(t, err)
+	s := result.(*corev1beta1.Seed)
+
+	assert.Equal(t, "seed-1", s.Name)
+	assert.Equal(t, "aws", s.Spec.Provider.Type)
+	assert.Equal(t, "eu-west-1", s.Spec.Provider.Region)
+	assert.Len(t, s.Spec.Taints, 1)
+	assert.NotNil(t, s.Spec.Settings)
+	assert.True(t, s.Spec.Settings.Scheduling.Visible)
+	assert.NotNil(t, s.Status.KubernetesVersion)
+	assert.NotEmpty(t, s.Status.Capacity)
+	assert.NotEmpty(t, s.Status.Allocatable)
+	assert.Len(t, s.Status.Conditions, 1)
+	assert.NotNil(t, s.Status.LastOperation)
+}
+
+func TestTransformSeed_StripsUnusedFields(t *testing.T) {
+	seed := &corev1beta1.Seed{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "seed-1",
+			ManagedFields:   []metav1.ManagedFieldsEntry{{Manager: "g"}},
+			Annotations:     map[string]string{"a": "b"},
+			Labels:          map[string]string{"l": "v"},
+			Finalizers:      []string{"f"},
+			OwnerReferences: []metav1.OwnerReference{{Name: "o"}},
+		},
+		Spec: corev1beta1.SeedSpec{
+			Provider: corev1beta1.SeedProvider{
+				Type:           "aws",
+				Region:         "eu-west-1",
+				ProviderConfig: &runtime.RawExtension{Raw: []byte(`{}`)},
+				Zones:          []string{"a", "b"},
+			},
+			Backup:             &corev1beta1.Backup{Provider: "aws"},
+			DNS:                corev1beta1.SeedDNS{Provider: &corev1beta1.SeedDNSProvider{Type: "aws-route53"}},
+			Networks:           corev1beta1.SeedNetworks{Pods: "10.0.0.0/16"},
+			Ingress:            &corev1beta1.Ingress{},
+			Volume:             &corev1beta1.SeedVolume{},
+			AccessRestrictions: []corev1beta1.AccessRestriction{{Name: "ar"}},
+			Extensions:         []corev1beta1.Extension{{Type: "ext"}},
+			Resources:          []corev1beta1.NamedResourceReference{{Name: "r"}},
+		},
+		Status: corev1beta1.SeedStatus{
+			Gardener:                             &corev1beta1.Gardener{Version: "1.90.0"},
+			ObservedGeneration:                   3,
+			ClusterIdentity:                      ptr.To("cid"),
+			ClientCertificateExpirationTimestamp: &metav1.Time{},
+		},
+	}
+
+	result, err := transformSeed(seed)
+	require.NoError(t, err)
+	s := result.(*corev1beta1.Seed)
+
+	assert.Nil(t, s.ManagedFields)
+	assert.Nil(t, s.Annotations)
+	assert.Equal(t, map[string]string{"l": "v"}, s.Labels)
+	assert.Nil(t, s.Finalizers)
+	assert.Nil(t, s.OwnerReferences)
+	assert.Nil(t, s.Spec.Backup)
+	assert.Equal(t, corev1beta1.SeedDNS{}, s.Spec.DNS)
+	assert.Equal(t, corev1beta1.SeedNetworks{}, s.Spec.Networks)
+	assert.Nil(t, s.Spec.Provider.ProviderConfig)
+	assert.Nil(t, s.Spec.Provider.Zones)
+	assert.Nil(t, s.Spec.Ingress)
+	assert.Nil(t, s.Spec.Volume)
+	assert.Nil(t, s.Spec.AccessRestrictions)
+	assert.Nil(t, s.Spec.Extensions)
+	assert.Nil(t, s.Spec.Resources)
+	assert.Nil(t, s.Status.Gardener)
+	assert.Equal(t, int64(0), s.Status.ObservedGeneration)
+	assert.Nil(t, s.Status.ClusterIdentity)
+	assert.Nil(t, s.Status.ClientCertificateExpirationTimestamp)
+}
+
+func TestTransformProject_RetainsUsedFields(t *testing.T) {
+	project := &corev1beta1.Project{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "my-project",
+			Annotations: map[string]string{"billing.gardener.cloud/costObject": "CO123", "billing.gardener.cloud/costObjectType": "IO"},
+		},
+		Spec: corev1beta1.ProjectSpec{
+			Namespace: ptr.To("garden-my-project"),
+			Owner:     &rbacv1.Subject{Kind: "User", Name: "owner@example.com"},
+			Members: []corev1beta1.ProjectMember{
+				{Subject: rbacv1.Subject{Kind: "User", Name: "user1", APIGroup: "rbac.authorization.k8s.io"}, Role: "admin", Roles: []string{"admin"}},
+				{Subject: rbacv1.Subject{Kind: "ServiceAccount", Name: "sa1", Namespace: "ns1"}, Role: "viewer"},
+			},
+		},
+		Status: corev1beta1.ProjectStatus{
+			Phase: corev1beta1.ProjectReady,
+		},
+	}
+
+	result, err := transformProject(project)
+	require.NoError(t, err)
+	p := result.(*corev1beta1.Project)
+
+	assert.Equal(t, "my-project", p.Name)
+	assert.Equal(t, "CO123", p.Annotations["billing.gardener.cloud/costObject"])
+	assert.Equal(t, "IO", p.Annotations["billing.gardener.cloud/costObjectType"])
+	assert.Equal(t, ptr.To("garden-my-project"), p.Spec.Namespace)
+	assert.Equal(t, "owner@example.com", p.Spec.Owner.Name)
+	assert.Len(t, p.Spec.Members, 2)
+	assert.Equal(t, "User", p.Spec.Members[0].Kind)
+	assert.Equal(t, "ServiceAccount", p.Spec.Members[1].Kind)
+	assert.Equal(t, corev1beta1.ProjectReady, p.Status.Phase)
+}
+
+func TestTransformProject_StripsUnusedFields(t *testing.T) {
+	project := &corev1beta1.Project{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "my-project",
+			ManagedFields:   []metav1.ManagedFieldsEntry{{Manager: "g"}},
+			Labels:          map[string]string{"l": "v"},
+			Finalizers:      []string{"f"},
+			OwnerReferences: []metav1.OwnerReference{{Name: "o"}},
+		},
+		Spec: corev1beta1.ProjectSpec{
+			Namespace:   ptr.To("garden-my-project"),
+			Description: ptr.To("desc"),
+			Purpose:     ptr.To("purpose"),
+			CreatedBy:   &rbacv1.Subject{Kind: "User", Name: "c"},
+			Tolerations: &corev1beta1.ProjectTolerations{},
+			Members: []corev1beta1.ProjectMember{
+				{Subject: rbacv1.Subject{Kind: "User", Name: "user1", APIGroup: "rbac", Namespace: "ns"}, Role: "admin", Roles: []string{"admin"}},
+			},
+		},
+		Status: corev1beta1.ProjectStatus{
+			Phase:                    corev1beta1.ProjectReady,
+			ObservedGeneration:       5,
+			StaleSinceTimestamp:      &metav1.Time{},
+			StaleAutoDeleteTimestamp: &metav1.Time{},
+			LastActivityTimestamp:    &metav1.Time{},
+		},
+	}
+
+	result, err := transformProject(project)
+	require.NoError(t, err)
+	p := result.(*corev1beta1.Project)
+
+	assert.Nil(t, p.ManagedFields)
+	assert.Equal(t, map[string]string{"l": "v"}, p.Labels)
+	assert.Nil(t, p.Finalizers)
+	assert.Nil(t, p.OwnerReferences)
+	assert.Nil(t, p.Spec.Description)
+	assert.Nil(t, p.Spec.Purpose)
+	assert.Nil(t, p.Spec.CreatedBy)
+	assert.Nil(t, p.Spec.Tolerations)
+
+	// Members: only Subject.Kind retained; everything else zeroed.
+	assert.Equal(t, "User", p.Spec.Members[0].Kind)
+	assert.Empty(t, p.Spec.Members[0].Name)
+	assert.Empty(t, p.Spec.Members[0].APIGroup)
+	assert.Empty(t, p.Spec.Members[0].Namespace)
+	assert.Empty(t, p.Spec.Members[0].Role)
+	assert.Nil(t, p.Spec.Members[0].Roles)
+
+	assert.Equal(t, int64(0), p.Status.ObservedGeneration)
+	assert.Nil(t, p.Status.StaleSinceTimestamp)
+	assert.Nil(t, p.Status.StaleAutoDeleteTimestamp)
+	assert.Nil(t, p.Status.LastActivityTimestamp)
+}
+
+func TestTransformSecretBinding_RetainsAndStrips(t *testing.T) {
+	sb := &corev1beta1.SecretBinding{ //nolint:staticcheck // SA1019
+		ObjectMeta: metav1.ObjectMeta{
+			Name:          "sb-1",
+			Namespace:     "garden-dev",
+			ManagedFields: []metav1.ManagedFieldsEntry{{Manager: "g"}},
+			Labels:        map[string]string{"l": "v"},
+			Annotations:   map[string]string{"a": "b"},
+			Finalizers:    []string{"f"},
+		},
+		SecretRef: corev1.SecretReference{
+			Name:      "secret-1",
+			Namespace: "garden-billing",
+		},
+		Provider: &corev1beta1.SecretBindingProvider{Type: "aws"}, //nolint:staticcheck // SA1019
+		Quotas:   []corev1.ObjectReference{{Name: "q"}},
+	}
+
+	result, err := transformSecretBinding(sb)
+	require.NoError(t, err)
+	s := result.(*corev1beta1.SecretBinding) //nolint:staticcheck // SA1019
+
+	assert.Equal(t, "sb-1", s.Name)
+	assert.Equal(t, "garden-dev", s.Namespace)
+	assert.Equal(t, "garden-billing", s.SecretRef.Namespace)
+	assert.Nil(t, s.ManagedFields)
+	assert.Equal(t, map[string]string{"l": "v"}, s.Labels)
+	assert.Nil(t, s.Annotations)
+	assert.Nil(t, s.Finalizers)
+	assert.Nil(t, s.Provider)
+	assert.Nil(t, s.Quotas)
+}
+
+func TestTransformCredentialsBinding_RetainsAndStrips(t *testing.T) {
+	cb := &securityv1alpha1.CredentialsBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:          "cb-1",
+			Namespace:     "garden-dev",
+			ManagedFields: []metav1.ManagedFieldsEntry{{Manager: "g"}},
+			Labels:        map[string]string{"l": "v"},
+			Annotations:   map[string]string{"a": "b"},
+			Finalizers:    []string{"f"},
+		},
+		CredentialsRef: corev1.ObjectReference{
+			Name:      "cred-1",
+			Namespace: "garden-billing",
+		},
+		Provider: securityv1alpha1.CredentialsBindingProvider{Type: "aws"},
+		Quotas:   []corev1.ObjectReference{{Name: "q"}},
+	}
+
+	result, err := transformCredentialsBinding(cb)
+	require.NoError(t, err)
+	c := result.(*securityv1alpha1.CredentialsBinding)
+
+	assert.Equal(t, "cb-1", c.Name)
+	assert.Equal(t, "garden-dev", c.Namespace)
+	assert.Equal(t, "garden-billing", c.CredentialsRef.Namespace)
+	assert.Nil(t, c.ManagedFields)
+	assert.Equal(t, map[string]string{"l": "v"}, c.Labels)
+	assert.Nil(t, c.Annotations)
+	assert.Nil(t, c.Finalizers)
+	assert.Equal(t, securityv1alpha1.CredentialsBindingProvider{}, c.Provider)
+	assert.Nil(t, c.Quotas)
+}
+
+func TestTransformManagedSeed_RetainsAndStrips(t *testing.T) {
+	ms := &seedmanagementv1alpha1.ManagedSeed{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:          "ms-1",
+			ManagedFields: []metav1.ManagedFieldsEntry{{Manager: "g"}},
+			Labels:        map[string]string{"l": "v"},
+			Annotations:   map[string]string{"a": "b"},
+			Finalizers:    []string{"f"},
+		},
+		Spec: seedmanagementv1alpha1.ManagedSeedSpec{
+			Shoot:     &seedmanagementv1alpha1.Shoot{Name: "my-shoot"},
+			Gardenlet: seedmanagementv1alpha1.GardenletConfig{Config: runtime.RawExtension{Raw: []byte(`{}`)}},
+		},
+		Status: seedmanagementv1alpha1.ManagedSeedStatus{
+			ObservedGeneration: 3,
+		},
+	}
+
+	result, err := transformManagedSeed(ms)
+	require.NoError(t, err)
+	m := result.(*seedmanagementv1alpha1.ManagedSeed)
+
+	assert.Equal(t, "ms-1", m.Name)
+	assert.Equal(t, "my-shoot", m.Spec.Shoot.Name)
+	assert.Nil(t, m.ManagedFields)
+	assert.Equal(t, map[string]string{"l": "v"}, m.Labels)
+	assert.Nil(t, m.Annotations)
+	assert.Nil(t, m.Finalizers)
+	assert.Equal(t, seedmanagementv1alpha1.GardenletConfig{}, m.Spec.Gardenlet)
+	assert.Equal(t, seedmanagementv1alpha1.ManagedSeedStatus{}, m.Status)
+}
+
+func TestTransformGardenlet_RetainsAndStrips(t *testing.T) {
+	gl := &seedmanagementv1alpha1.Gardenlet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:          "gl-1",
+			Generation:    7,
+			ManagedFields: []metav1.ManagedFieldsEntry{{Manager: "g"}},
+			Labels:        map[string]string{"l": "v"},
+			Annotations:   map[string]string{"a": "b"},
+			Finalizers:    []string{"f"},
+		},
+		Spec: seedmanagementv1alpha1.GardenletSpec{
+			Config: runtime.RawExtension{Raw: []byte(`{}`)},
+		},
+		Status: seedmanagementv1alpha1.GardenletStatus{
+			ObservedGeneration: 6,
+			Conditions:         []corev1beta1.Condition{{Type: "Reconciled", Status: "True"}},
+		},
+	}
+
+	result, err := transformGardenlet(gl)
+	require.NoError(t, err)
+	g := result.(*seedmanagementv1alpha1.Gardenlet)
+
+	assert.Equal(t, "gl-1", g.Name)
+	assert.Equal(t, int64(7), g.Generation)
+	assert.Equal(t, int64(6), g.Status.ObservedGeneration)
+	assert.Len(t, g.Status.Conditions, 1)
+	assert.Nil(t, g.ManagedFields)
+	assert.Equal(t, map[string]string{"l": "v"}, g.Labels)
+	assert.Nil(t, g.Annotations)
+	assert.Nil(t, g.Finalizers)
+	assert.Equal(t, seedmanagementv1alpha1.GardenletSpec{}, g.Spec)
+}
+
+func TestTransformCoreClusterScoped_DispatchesSeed(t *testing.T) {
+	seed := &corev1beta1.Seed{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:          "seed-1",
+			ManagedFields: []metav1.ManagedFieldsEntry{{Manager: "g"}},
+		},
+		Spec: corev1beta1.SeedSpec{
+			Provider: corev1beta1.SeedProvider{Type: "aws", Region: "eu-west-1"},
+		},
+	}
+
+	result, err := transformCoreClusterScoped(seed)
+	require.NoError(t, err)
+	s := result.(*corev1beta1.Seed)
+	assert.Equal(t, "seed-1", s.Name)
+	assert.Equal(t, "aws", s.Spec.Provider.Type)
+	assert.Nil(t, s.ManagedFields)
+}
+
+func TestTransformCoreClusterScoped_DispatchesProject(t *testing.T) {
+	project := &corev1beta1.Project{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:          "proj-1",
+			ManagedFields: []metav1.ManagedFieldsEntry{{Manager: "g"}},
+		},
+	}
+
+	result, err := transformCoreClusterScoped(project)
+	require.NoError(t, err)
+	p := result.(*corev1beta1.Project)
+	assert.Equal(t, "proj-1", p.Name)
+	assert.Nil(t, p.ManagedFields)
+}
+
+func TestTransformCoreClusterScoped_PassthroughUnknown(t *testing.T) {
+	obj := "unknown"
+	result, err := transformCoreClusterScoped(obj)
+	require.NoError(t, err)
+	assert.Equal(t, "unknown", result)
+}
+
+func TestTransformSeedManagement_DispatchesManagedSeed(t *testing.T) {
+	ms := &seedmanagementv1alpha1.ManagedSeed{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:          "ms-1",
+			ManagedFields: []metav1.ManagedFieldsEntry{{Manager: "g"}},
+		},
+		Spec: seedmanagementv1alpha1.ManagedSeedSpec{
+			Shoot: &seedmanagementv1alpha1.Shoot{Name: "s"},
+		},
+	}
+
+	result, err := transformSeedManagement(ms)
+	require.NoError(t, err)
+	m := result.(*seedmanagementv1alpha1.ManagedSeed)
+	assert.Equal(t, "ms-1", m.Name)
+	assert.Nil(t, m.ManagedFields)
+}
+
+func TestTransformSeedManagement_DispatchesGardenlet(t *testing.T) {
+	gl := &seedmanagementv1alpha1.Gardenlet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:          "gl-1",
+			Generation:    5,
+			ManagedFields: []metav1.ManagedFieldsEntry{{Manager: "g"}},
+		},
+		Status: seedmanagementv1alpha1.GardenletStatus{ObservedGeneration: 4},
+	}
+
+	result, err := transformSeedManagement(gl)
+	require.NoError(t, err)
+	g := result.(*seedmanagementv1alpha1.Gardenlet)
+	assert.Equal(t, "gl-1", g.Name)
+	assert.Equal(t, int64(5), g.Generation)
+	assert.Nil(t, g.ManagedFields)
+}
+
+func TestTransformSeedManagement_PassthroughUnknown(t *testing.T) {
+	obj := 42
+	result, err := transformSeedManagement(obj)
+	require.NoError(t, err)
+	assert.Equal(t, 42, result)
+}

--- a/receiver/gardenerreceiver/transform_test.go
+++ b/receiver/gardenerreceiver/transform_test.go
@@ -24,10 +24,13 @@ import (
 func TestTransformShoot_RetainsUsedFields(t *testing.T) {
 	shoot := &corev1beta1.Shoot{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:              "my-shoot",
-			Namespace:         "garden-dev",
-			UID:               "abc-123",
-			Labels:            map[string]string{"shoot.gardener.cloud/status": "healthy"},
+			Name:      "my-shoot",
+			Namespace: "garden-dev",
+			UID:       "abc-123",
+			Labels: map[string]string{
+				"shoot.gardener.cloud/status": "healthy",
+				"unused":                      "drop-me",
+			},
 			CreationTimestamp: metav1.Now(),
 		},
 		Spec: corev1beta1.ShootSpec{
@@ -120,7 +123,7 @@ func TestTransformShoot_RetainsUsedFields(t *testing.T) {
 
 	assert.Equal(t, "my-shoot", s.Name)
 	assert.Equal(t, "garden-dev", s.Namespace)
-	assert.Equal(t, "healthy", s.Labels["shoot.gardener.cloud/status"])
+	assert.Equal(t, map[string]string{"shoot.gardener.cloud/status": "healthy"}, s.Labels)
 	assert.NotEmpty(t, s.CreationTimestamp)
 	assert.Equal(t, "aws", s.Spec.Provider.Type)
 	assert.Equal(t, "eu-west-1", s.Spec.Region)
@@ -163,9 +166,13 @@ func TestTransformShoot_RetainsUsedFields(t *testing.T) {
 func TestTransformShoot_StripsUnusedFields(t *testing.T) {
 	shoot := &corev1beta1.Shoot{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            "my-shoot",
-			Namespace:       "garden-dev",
-			ManagedFields:   []metav1.ManagedFieldsEntry{{Manager: "gardener"}},
+			Name:          "my-shoot",
+			Namespace:     "garden-dev",
+			ManagedFields: []metav1.ManagedFieldsEntry{{Manager: "gardener"}},
+			Labels: map[string]string{
+				"shoot.gardener.cloud/status": "progressing",
+				"foo":                         "bar",
+			},
 			Annotations:     map[string]string{"foo": "bar"},
 			Finalizers:      []string{"gardener"},
 			OwnerReferences: []metav1.OwnerReference{{Name: "owner"}},
@@ -264,6 +271,7 @@ func TestTransformShoot_StripsUnusedFields(t *testing.T) {
 
 	// ObjectMeta stripped
 	assert.Nil(t, s.ManagedFields)
+	assert.Equal(t, map[string]string{"shoot.gardener.cloud/status": "progressing"}, s.Labels)
 	assert.Nil(t, s.Annotations)
 	assert.Nil(t, s.Finalizers)
 	assert.Nil(t, s.OwnerReferences)
@@ -391,7 +399,7 @@ func TestTransformShoot_UnknownType(t *testing.T) {
 
 func TestTransformSeed_RetainsUsedFields(t *testing.T) {
 	seed := &corev1beta1.Seed{
-		ObjectMeta: metav1.ObjectMeta{Name: "seed-1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "seed-1", Labels: map[string]string{"unused": "drop-me"}},
 		Spec: corev1beta1.SeedSpec{
 			Provider: corev1beta1.SeedProvider{
 				Type:   "aws",
@@ -419,6 +427,7 @@ func TestTransformSeed_RetainsUsedFields(t *testing.T) {
 	s := result.(*corev1beta1.Seed)
 
 	assert.Equal(t, "seed-1", s.Name)
+	assert.Nil(t, s.Labels)
 	assert.Equal(t, "aws", s.Spec.Provider.Type)
 	assert.Equal(t, "eu-west-1", s.Spec.Provider.Region)
 	assert.Len(t, s.Spec.Taints, 1)
@@ -471,7 +480,7 @@ func TestTransformSeed_StripsUnusedFields(t *testing.T) {
 
 	assert.Nil(t, s.ManagedFields)
 	assert.Nil(t, s.Annotations)
-	assert.Equal(t, map[string]string{"l": "v"}, s.Labels)
+	assert.Nil(t, s.Labels)
 	assert.Nil(t, s.Finalizers)
 	assert.Nil(t, s.OwnerReferences)
 	assert.Nil(t, s.Spec.Backup)
@@ -493,8 +502,13 @@ func TestTransformSeed_StripsUnusedFields(t *testing.T) {
 func TestTransformProject_RetainsUsedFields(t *testing.T) {
 	project := &corev1beta1.Project{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "my-project",
-			Annotations: map[string]string{"billing.gardener.cloud/costObject": "CO123", "billing.gardener.cloud/costObjectType": "IO"},
+			Name: "my-project",
+			Annotations: map[string]string{
+				"billing.gardener.cloud/costObject":     "CO123",
+				"billing.gardener.cloud/costObjectType": "IO",
+				"unused":                                "drop-me",
+			},
+			Labels: map[string]string{"unused": "drop-me"},
 		},
 		Spec: corev1beta1.ProjectSpec{
 			Namespace: ptr.To("garden-my-project"),
@@ -514,8 +528,11 @@ func TestTransformProject_RetainsUsedFields(t *testing.T) {
 	p := result.(*corev1beta1.Project)
 
 	assert.Equal(t, "my-project", p.Name)
-	assert.Equal(t, "CO123", p.Annotations["billing.gardener.cloud/costObject"])
-	assert.Equal(t, "IO", p.Annotations["billing.gardener.cloud/costObjectType"])
+	assert.Equal(t, map[string]string{
+		"billing.gardener.cloud/costObject":     "CO123",
+		"billing.gardener.cloud/costObjectType": "IO",
+	}, p.Annotations)
+	assert.Nil(t, p.Labels)
 	assert.Equal(t, ptr.To("garden-my-project"), p.Spec.Namespace)
 	assert.Equal(t, "owner@example.com", p.Spec.Owner.Name)
 	assert.Len(t, p.Spec.Members, 2)
@@ -527,8 +544,13 @@ func TestTransformProject_RetainsUsedFields(t *testing.T) {
 func TestTransformProject_StripsUnusedFields(t *testing.T) {
 	project := &corev1beta1.Project{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            "my-project",
-			ManagedFields:   []metav1.ManagedFieldsEntry{{Manager: "g"}},
+			Name:          "my-project",
+			ManagedFields: []metav1.ManagedFieldsEntry{{Manager: "g"}},
+			Annotations: map[string]string{
+				"billing.gardener.cloud/costObject":     "CO123",
+				"billing.gardener.cloud/costObjectType": "IO",
+				"unused":                                "drop-me",
+			},
 			Labels:          map[string]string{"l": "v"},
 			Finalizers:      []string{"f"},
 			OwnerReferences: []metav1.OwnerReference{{Name: "o"}},
@@ -557,7 +579,11 @@ func TestTransformProject_StripsUnusedFields(t *testing.T) {
 	p := result.(*corev1beta1.Project)
 
 	assert.Nil(t, p.ManagedFields)
-	assert.Equal(t, map[string]string{"l": "v"}, p.Labels)
+	assert.Equal(t, map[string]string{
+		"billing.gardener.cloud/costObject":     "CO123",
+		"billing.gardener.cloud/costObjectType": "IO",
+	}, p.Annotations)
+	assert.Nil(t, p.Labels)
 	assert.Nil(t, p.Finalizers)
 	assert.Nil(t, p.OwnerReferences)
 	assert.Nil(t, p.Spec.Description)
@@ -605,7 +631,7 @@ func TestTransformSecretBinding_RetainsAndStrips(t *testing.T) {
 	assert.Equal(t, "garden-dev", s.Namespace)
 	assert.Equal(t, "garden-billing", s.SecretRef.Namespace)
 	assert.Nil(t, s.ManagedFields)
-	assert.Equal(t, map[string]string{"l": "v"}, s.Labels)
+	assert.Nil(t, s.Labels)
 	assert.Nil(t, s.Annotations)
 	assert.Nil(t, s.Finalizers)
 	assert.Nil(t, s.Provider)
@@ -638,7 +664,7 @@ func TestTransformCredentialsBinding_RetainsAndStrips(t *testing.T) {
 	assert.Equal(t, "garden-dev", c.Namespace)
 	assert.Equal(t, "garden-billing", c.CredentialsRef.Namespace)
 	assert.Nil(t, c.ManagedFields)
-	assert.Equal(t, map[string]string{"l": "v"}, c.Labels)
+	assert.Nil(t, c.Labels)
 	assert.Nil(t, c.Annotations)
 	assert.Nil(t, c.Finalizers)
 	assert.Equal(t, securityv1alpha1.CredentialsBindingProvider{}, c.Provider)
@@ -670,7 +696,7 @@ func TestTransformManagedSeed_RetainsAndStrips(t *testing.T) {
 	assert.Equal(t, "ms-1", m.Name)
 	assert.Equal(t, "my-shoot", m.Spec.Shoot.Name)
 	assert.Nil(t, m.ManagedFields)
-	assert.Equal(t, map[string]string{"l": "v"}, m.Labels)
+	assert.Nil(t, m.Labels)
 	assert.Nil(t, m.Annotations)
 	assert.Nil(t, m.Finalizers)
 	assert.Equal(t, seedmanagementv1alpha1.GardenletConfig{}, m.Spec.Gardenlet)
@@ -705,7 +731,7 @@ func TestTransformGardenlet_RetainsAndStrips(t *testing.T) {
 	assert.Equal(t, int64(6), g.Status.ObservedGeneration)
 	assert.Len(t, g.Status.Conditions, 1)
 	assert.Nil(t, g.ManagedFields)
-	assert.Equal(t, map[string]string{"l": "v"}, g.Labels)
+	assert.Nil(t, g.Labels)
 	assert.Nil(t, g.Annotations)
 	assert.Nil(t, g.Finalizers)
 	assert.Equal(t, seedmanagementv1alpha1.GardenletSpec{}, g.Spec)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select kind for this pull request.
If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

The Gardener metrics receiver uses an informer cache to subscribe to all resources that are relevant for the used configuration. These resources are cached by the informer. For large landscapes, this can result in a significant memory use for the cache. Since the receiver only reads a small set of the attributes of the API resources, this PR introduces a [TransformFunc](https://pkg.go.dev/k8s.io/client-go@v0.35.2/tools/cache#TransformFunc) to remove all unnecessary attributes from the received objects before writing to the informer cache. Note that the implementation mutates received objects, which requires v1.27 or later.

**Which issue(s) this PR fixes**:
https://github.com/gardener/observability/issues/57

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Optimize informer cache usage by removing unnecessary attributes from cached objects
```
