### PR TITLE
Adjust to Gardener API deprecations

### DIFF
--- a/receiver/gardenerreceiver/shoot.go
+++ b/receiver/gardenerreceiver/shoot.go
@@ -586,24 +586,22 @@ func (r *gardenerReceiver) collectShootCustomizationMetrics(sm *pmetric.ScopeMet
 	}
 
 	var (
-		hibernationEnabled     int64
-		hibernationScheduled   int64
-		maintenanceWindow      int64
-		autoUpdateK8s          int64
-		autoUpdateMachineImage int64
-		nginxIngressEnabled    int64
-		kubeDashboardEnabled   int64
-		multipleWorkerPools    int64
-		multiZoneWorkers       int64
-		customDomain           int64
-		workerTaints           int64
-		workerLabels           int64
-		workerAnnotations      int64
-		auditPolicyCount       int64
-		oidcConfigCount        int64
-		nodeCIDRMaskCount      int64
-		hpaKCMCount            int64
-		podPIDLimitCount       int64
+		hibernationEnabled            int64
+		hibernationScheduled          int64
+		maintenanceWindow             int64
+		autoUpdateK8s                 int64
+		autoUpdateMachineImage        int64
+		multipleWorkerPools           int64
+		multiZoneWorkers              int64
+		customDomain                  int64
+		workerTaints                  int64
+		workerLabels                  int64
+		workerAnnotations             int64
+		auditPolicyCount              int64
+		structuredAuthenticationCount int64
+		nodeCIDRMaskCount             int64
+		hpaKCMCount                   int64
+		podPIDLimitCount              int64
 	)
 
 	extensionCounts := map[string]int64{}
@@ -636,15 +634,6 @@ func (r *gardenerReceiver) collectShootCustomizationMetrics(sm *pmetric.ScopeMet
 				if shoot.Spec.Maintenance.AutoUpdate.MachineImageVersion != nil && *shoot.Spec.Maintenance.AutoUpdate.MachineImageVersion {
 					autoUpdateMachineImage++
 				}
-			}
-		}
-
-		if shoot.Spec.Addons != nil {
-			if shoot.Spec.Addons.NginxIngress != nil && shoot.Spec.Addons.NginxIngress.Enabled {
-				nginxIngressEnabled++
-			}
-			if shoot.Spec.Addons.KubernetesDashboard != nil && shoot.Spec.Addons.KubernetesDashboard.Enabled {
-				kubeDashboardEnabled++
 			}
 		}
 
@@ -702,8 +691,8 @@ func (r *gardenerReceiver) collectShootCustomizationMetrics(sm *pmetric.ScopeMet
 			if apiServer.AuditConfig != nil && apiServer.AuditConfig.AuditPolicy != nil {
 				auditPolicyCount++
 			}
-			if apiServer.OIDCConfig != nil { //nolint:staticcheck
-				oidcConfigCount++
+			if apiServer.StructuredAuthentication != nil && apiServer.StructuredAuthentication.ConfigMapName != "" {
+				structuredAuthenticationCount++
 			}
 			for fg, enabled := range apiServer.FeatureGates {
 				if enabled {
@@ -762,8 +751,6 @@ func (r *gardenerReceiver) collectShootCustomizationMetrics(sm *pmetric.ScopeMet
 		{"garden.shoots.maintenance.window_total", "Count of shoots with a maintenance window configured", maintenanceWindow},
 		{"garden.shoots.maintenance.autoupdate.k8s_version_total", "Count of shoots with auto-update for kubernetes versions configured", autoUpdateK8s},
 		{"garden.shoots.maintenance.autoupdate.image_version_total", "Count of shoots with auto-update for machine image versions configured", autoUpdateMachineImage},
-		{"garden.shoots.custom.addon.nginx_ingress_total", "Count of shoots with nginx ingress controller addon enabled", nginxIngressEnabled},
-		{"garden.shoots.custom.addon.kube_dashboard_total", "Count of shoots with kubernetes dashboard addon enabled", kubeDashboardEnabled},
 		{"garden.shoots.custom.worker.multiple_pools_total", "Count of shoots with multiple worker pools", multipleWorkerPools},
 		{"garden.shoots.custom.worker.multi_zones_total", "Count of shoots with multi zone worker pools", multiZoneWorkers},
 		{"garden.shoots.custom.network.custom_domain_total", "Count of shoots which use a custom DNS domain", customDomain},
@@ -771,7 +758,7 @@ func (r *gardenerReceiver) collectShootCustomizationMetrics(sm *pmetric.ScopeMet
 		{"garden.shoots.custom.worker.labels_total", "Count of shoots with worker pool labels", workerLabels},
 		{"garden.shoots.custom.worker.annotations_total", "Count of shoots with worker pool annotations", workerAnnotations},
 		{"garden.shoots.custom.apiserver.audit_policy_total", "Count of shoots with an audit log policy configured for the kube apiserver", auditPolicyCount},
-		{"garden.shoots.custom.apiserver.oidc_config_total", "Count of shoots with an OIDC configuration for the kube apiserver", oidcConfigCount},
+		{"garden.shoots.custom.apiserver.structured_authentication_total", "Count of shoots with a structured authentication configuration for the kube apiserver", structuredAuthenticationCount},
 		{"garden.shoots.custom.kcm.node_cidr_mask_size_total", "Count of shoots which have node CIDR mask size configured on the kube controller manager", nodeCIDRMaskCount},
 		{"garden.shoots.custom.kcm.horizontal_pod_autoscale_total", "Count of shoots with horizontal pod autoscaling for the kube controller manager", hpaKCMCount},
 		{"garden.shoots.custom.kubelet.pod_pid_limit_total", "Count of shoots which have a pod PID limit configured for the kubelet(s)", podPIDLimitCount},

--- a/receiver/gardenerreceiver/shoot_test.go
+++ b/receiver/gardenerreceiver/shoot_test.go
@@ -662,10 +662,6 @@ func TestCollectShootCustomizationMetrics(t *testing.T) {
 					MachineImageVersion: ptr.To(true),
 				},
 			},
-			Addons: &corev1beta1.Addons{
-				NginxIngress:        &corev1beta1.NginxIngress{Addon: corev1beta1.Addon{Enabled: true}},
-				KubernetesDashboard: &corev1beta1.KubernetesDashboard{Addon: corev1beta1.Addon{Enabled: true}},
-			},
 		},
 	}
 
@@ -685,7 +681,7 @@ func TestCollectShootCustomizationMetrics(t *testing.T) {
 	sm := r.initScopeMetrics(&md)
 	r.collectShootCustomizationMetrics(&sm, nowTimestamp())
 
-	require.Equal(t, 18, md.MetricCount(), "expected 18 customization metrics")
+	require.Equal(t, 16, md.MetricCount(), "expected 16 customization metrics")
 
 	names := map[string]int64{}
 	for i := 0; i < md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().Len(); i++ {
@@ -698,8 +694,6 @@ func TestCollectShootCustomizationMetrics(t *testing.T) {
 	require.Equal(t, int64(1), names["garden.shoots.maintenance.window_total"])
 	require.Equal(t, int64(1), names["garden.shoots.maintenance.autoupdate.k8s_version_total"])
 	require.Equal(t, int64(1), names["garden.shoots.maintenance.autoupdate.image_version_total"])
-	require.Equal(t, int64(1), names["garden.shoots.custom.addon.nginx_ingress_total"])
-	require.Equal(t, int64(1), names["garden.shoots.custom.addon.kube_dashboard_total"])
 	require.Equal(t, int64(1), names["garden.shoots.custom.worker.multiple_pools_total"])
 	require.Equal(t, int64(1), names["garden.shoots.custom.worker.multi_zones_total"])
 }
@@ -1226,9 +1220,9 @@ func TestCollectShootCustomizationMetrics_NoOptionals(t *testing.T) {
 	}
 	names := collectCustomizationMetrics(t, shoot)
 	assert.Equal(t, int64(0), names["garden.shoots.hibernation.enabled_total"])
-	assert.Equal(t, int64(0), names["garden.shoots.custom.addon.nginx_ingress_total"])
+	assert.Equal(t, int64(0), names["garden.shoots.custom.apiserver.structured_authentication_total"])
 	assert.Equal(t, int64(0), names["garden.shoots.custom.worker.multiple_pools_total"])
-	assert.Equal(t, int64(18), int64(len(names)), "expected exactly 18 scalar metrics")
+	assert.Equal(t, int64(16), int64(len(names)), "expected exactly 16 scalar metrics")
 }
 
 func TestCollectShootCustomizationMetrics_FeatureGates(t *testing.T) {
@@ -1429,6 +1423,61 @@ func TestCollectShootCustomizationMetrics_Extensions(t *testing.T) {
 		}
 	}
 	t.Fatal("extensions metric not found")
+}
+
+func TestCollectShootCustomizationMetrics_StructuredAuthentication(t *testing.T) {
+	mkShoot := func(name string, sa *corev1beta1.StructuredAuthentication) *corev1beta1.Shoot {
+		return &corev1beta1.Shoot{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "garden-dev"},
+			Spec: corev1beta1.ShootSpec{
+				Provider: corev1beta1.Provider{Type: "aws"},
+				Region:   "eu-west-1",
+				Kubernetes: corev1beta1.Kubernetes{
+					Version: "1.28.0",
+					KubeAPIServer: &corev1beta1.KubeAPIServerConfig{
+						StructuredAuthentication: sa,
+					},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name  string
+		sa    *corev1beta1.StructuredAuthentication
+		count int64
+	}{
+		{name: "configured", sa: &corev1beta1.StructuredAuthentication{ConfigMapName: "auth-cm"}, count: 1},
+		{name: "empty configmap name not counted", sa: &corev1beta1.StructuredAuthentication{ConfigMapName: ""}, count: 0},
+		{name: "nil not counted", sa: nil, count: 0},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			names := collectCustomizationMetrics(t, mkShoot("sa-shoot", tc.sa))
+			assert.Equal(t, tc.count, names["garden.shoots.custom.apiserver.structured_authentication_total"])
+		})
+	}
+}
+
+func TestCollectShootCustomizationMetrics_StructuredAuthentication_MultipleShoots(t *testing.T) {
+	// Three shoots: two with structured authentication configured, one without.
+	mkShoot := func(name string, sa *corev1beta1.StructuredAuthentication) *corev1beta1.Shoot {
+		return &corev1beta1.Shoot{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "garden-dev"},
+			Spec: corev1beta1.ShootSpec{
+				Provider:   corev1beta1.Provider{Type: "aws"},
+				Region:     "eu-west-1",
+				Kubernetes: corev1beta1.Kubernetes{Version: "1.28.0", KubeAPIServer: &corev1beta1.KubeAPIServerConfig{StructuredAuthentication: sa}},
+			},
+		}
+	}
+	names := collectCustomizationMetrics(t,
+		mkShoot("s1", &corev1beta1.StructuredAuthentication{ConfigMapName: "auth-cm-1"}),
+		mkShoot("s2", &corev1beta1.StructuredAuthentication{ConfigMapName: "auth-cm-2"}),
+		mkShoot("s3", nil),
+	)
+	assert.Equal(t, int64(2), names["garden.shoots.custom.apiserver.structured_authentication_total"])
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select kind for this pull request.
If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind cleanup

**What this PR does / why we need it**:

The Gardener API deprecated the NGINX ingress and Kubernetes dashboard Shoot addons. This change removes the corresponding metrics and all references to the deprecated API fields. Furthermore, the OIDC configuration for the API server has been removed from the Gardener API. The corresponding metric is now based on the use of structured authentication.

**Which issue(s) this PR fixes**:
See https://github.com/gardener/gardener/pull/14615, https://github.com/gardener/gardener/pull/13845
Part of: https://github.com/gardener/observability/issues/57

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Adjust to Gardener API deprecations
```
