### PR TITLE
Add Renovate grouping for Gardener dependencies

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -49,6 +49,15 @@
       "groupName": "Kubernetes dependencies",
       "matchPackageNames": ["/^k8s\\.io\\//", "/^sigs\\.k8s\\.io\\//"]
     },
+    // Group gardener modules so github.com/gardener/gardener and
+    // github.com/gardener/gardener/pkg/apis are bumped together
+    {
+      "groupName": "Gardener",
+      "matchPackageNames": [
+        "github.com/gardener/gardener",
+        "/^github\\.com\\/gardener\\/gardener\\//"
+      ]
+    },
     // Group golang.org/x packages
     {
       "groupName": "golang.org/x",

--- a/renovate.json5
+++ b/renovate.json5
@@ -54,8 +54,7 @@
     {
       "groupName": "Gardener",
       "matchPackageNames": [
-        "github.com/gardener/gardener",
-        "/^github\\.com\\/gardener\\/gardener\\//"
+        "/^github\\.com\\/gardener\\/gardener(\\/|$)/"
       ]
     },
     // Group golang.org/x packages


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select kind for this pull request.
If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:

Add Renovate grouping for Gardener dependencies

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
Add Renovate grouping for Gardener dependencies
```
