### PR TITLE
fix: send STOPPING=1 only during SIGINT / SIGTERM

### DIFF
--- a/extension/sdnotify/README.md
+++ b/extension/sdnotify/README.md
@@ -105,6 +105,7 @@ With this unit:
 - `systemctl reload otelcol` sends `SIGHUP`; systemd tracks the reload via
   `RELOADING=1` -> `READY=1` and the collector re-reads its config in place
   (`MainPID` unchanged).
-- `systemctl stop otelcol` sees `STOPPING=1` as the pipelines drain.
+- `systemctl stop otelcol` sends `SIGTERM`; the extension emits `STOPPING=1`
+  from its dedicated `SIGINT`/`SIGTERM` handler, then the pipelines drain.
 - If the collector stops sending `WATCHDOG=1` for longer than `WatchdogSec`
   (e.g. it deadlocks), systemd restarts it.

--- a/extension/sdnotify/README.md
+++ b/extension/sdnotify/README.md
@@ -17,8 +17,8 @@ unit it will:
 
 - send `READY=1` once all pipelines have started, so `systemctl start` returns
   only when the collector is actually accepting data;
-- send `STOPPING=1` when the pipelines shut down, so systemd knows the process
-  is going away deliberately;
+- send `STOPPING=1` on genuine process termination (`SIGINT` / `SIGTERM`),
+  so systemd knows the process is going away deliberately;
 - on `SIGHUP` send `RELOADING=1` (paired with `MONOTONIC_USEC` as required by 
   `sd_notify(3)`) so systemd's state machine correctly reflects that a reload is in progress;
 - when systemd has set `WATCHDOG_USEC` for the collector's PID, send
@@ -34,9 +34,16 @@ The extension does not itself drive a reload or cycle the process on SIGHUP.
 The OpenTelemetry Collector has its own SIGHUP handler that performs an
 **in-process** reload: it calls `service.Shutdown` and then re-runs
 `setupConfigurationComponents` to rebuild the pipelines from the current
-config on disk. That reload invokes `PipelineWatcher.NotReady` on this
-extension (which sends `STOPPING=1`) and, once the fresh pipelines are up,
-`PipelineWatcher.Ready` (which sends `READY=1` again).
+config on disk. On the incoming SIGHUP, the extension emits
+`RELOADING=1` (with `MONOTONIC_USEC`); once the rebuilt pipelines are up,
+`PipelineWatcher.Ready` is called on the fresh extension instance and it sends
+a second `READY=1`. `STOPPING=1` is deliberately NOT emitted during a reload -
+otelcol's reload path invokes `PipelineWatcher.NotReady` on this extension,
+but a reload is indistinguishable from a real shutdown at that hook, so
+`NotReady` is a no-op here. Under `Type=notify-reload`, sending `STOPPING=1`
+mid-reload would flip the unit into `deactivating` and ignore the subsequent
+`READY=1`. Instead, `STOPPING=1` is emitted from a dedicated `SIGINT`/`SIGTERM`
+handler in the extension, which fires only on genuine termination.
 
 ## Watchdog
 

--- a/extension/sdnotify/sdnotify.go
+++ b/extension/sdnotify/sdnotify.go
@@ -27,6 +27,7 @@ type sdnotify struct {
 	isNoop bool
 
 	sigCh        chan os.Signal
+	termCh       chan os.Signal
 	shutdownCh   chan struct{}
 	shutdownOnce sync.Once
 }
@@ -44,6 +45,7 @@ func newSDNotify(cfg *Config, logger *zap.Logger) *sdnotify {
 		cfg:        cfg,
 		logger:     logger,
 		sigCh:      make(chan os.Signal, 1),
+		termCh:     make(chan os.Signal, 1),
 		shutdownCh: make(chan struct{}),
 	}
 }
@@ -97,6 +99,24 @@ func (s *sdnotify) Start(_ context.Context, host component.Host) error {
 		}
 	}()
 
+	// STOPPING=1 must be sent only on real termination, never during a reload.
+	signal.Notify(s.termCh, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		select {
+		case <-s.shutdownCh:
+			return
+		case <-s.termCh:
+			sent, err := daemon.SdNotify(false, daemon.SdNotifyStopping)
+			if err != nil {
+				s.logger.Warn("sdnotify STOPPING=1 failed", zap.Error(err))
+				return
+			} else if sent {
+				s.logger.Info("sdnotify: sent STOPPING=1 to systemd")
+			}
+		}
+	}()
+
 	// Watchdog auto-enables whenever systemd has set WATCHDOG_USEC for our
 	// PID. SdWatchdogEnabled returns 0 when it didn't, or when WATCHDOG_PID
 	// points at a different process - both are valid "not enabled" states
@@ -138,6 +158,7 @@ func (s *sdnotify) Shutdown(_ context.Context) error {
 	s.shutdownOnce.Do(func() {
 		close(s.shutdownCh)
 		signal.Stop(s.sigCh)
+		signal.Stop(s.termCh)
 	})
 	return nil
 }
@@ -156,14 +177,5 @@ func (s *sdnotify) Ready() error {
 }
 
 func (s *sdnotify) NotReady() error {
-	sent, err := daemon.SdNotify(false, daemon.SdNotifyStopping)
-	if err != nil {
-		// Best-effort: don't block shutdown on a notify failure.
-		s.logger.Warn("sdnotify STOPPING=1 failed", zap.Error(err))
-		return nil
-	}
-	if sent {
-		s.logger.Info("sdnotify: sent STOPPING=1 to systemd")
-	}
 	return nil
 }

--- a/extension/sdnotify/sdnotify_test.go
+++ b/extension/sdnotify/sdnotify_test.go
@@ -86,19 +86,19 @@ func TestReady_SendsREADY(t *testing.T) {
 	}
 }
 
-func TestNotReady_SendsSTOPPING(t *testing.T) {
+func TestSIGTERM_SendsSTOPPING(t *testing.T) {
 	msgs := startFakeNotifySocket(t)
 
 	s := newSDNotify(&Config{}, zaptest.NewLogger(t))
 	require.NoError(t, s.Start(context.Background(), noopHost{}))
 	t.Cleanup(func() { _ = s.Shutdown(context.Background()) })
 
-	require.NoError(t, s.NotReady())
+	require.NoError(t, syscall.Kill(os.Getpid(), syscall.SIGTERM))
 	select {
 	case got := <-msgs:
 		require.Equal(t, "STOPPING=1", got)
 	case <-time.After(2 * time.Second):
-		t.Fatal("no datagram received on fake NOTIFY_SOCKET")
+		t.Fatal("no STOPPING=1 datagram received after SIGTERM")
 	}
 }
 
@@ -230,10 +230,9 @@ func startSystemdContainer(
 // scenario image (valid config, reachable exporter):
 //   - boot -> unit reaches active/running (only possible if READY=1 was sent)
 //   - SIGHUP -> the extension emits RELOADING=1 and otelcol's own reload
-//     drives NotReady/Ready, producing a STOPPING=1 -> READY=1 pair in the
-//     same PID (Type=notify-reload contract: no process cycling, NRestarts=0)
-//   - systemctl stop -> unit exits cleanly (Result=success), confirming
-//     STOPPING=1 was emitted before shutdown
+//     rebuilds the pipelines, producing a second READY=1 in the same PID.
+//   - systemctl stop -> the extension's SIGTERM handler emits STOPPING=1
+//     and the unit exits cleanly (Result=success)
 func TestSDNotify_HappyPath_LifecycleIntegration(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	t.Cleanup(cancel)
@@ -278,17 +277,19 @@ func TestSDNotify_HappyPath_LifecycleIntegration(t *testing.T) {
 	require.Equal(t, beforePID, afterPID,
 		"MainPID must not change on in-process reload; before=%s after=%s", beforePID, afterPID)
 
-	// The journal should contain the full reload sequence:
-	// RELOADING=1 -> STOPPING=1 (from PipelineWatcher.NotReady) -> READY=1.
+	// Reload journal: RELOADING=1 + >=2 READY=1 - the second is the post-reload
+	// ready. STOPPING=1 must NOT appear yet - the extension only emits it on
+	// genuine termination (SIGINT / SIGTERM), never mid-reload.
 	journal := execAndCollect(ctx, t, ctr, "journalctl", "-u", "otelcol.service", "--no-pager")
 	require.Contains(t, journal, "sent RELOADING=1 to systemd",
 		"expected RELOADING=1 log line after SIGHUP; journal:\n%s", journal)
-	require.Contains(t, journal, "sent STOPPING=1 to systemd",
-		"expected STOPPING=1 log line from PipelineWatcher.NotReady during reload; journal:\n%s", journal)
+	require.NotContains(t, journal, "sent STOPPING=1 to systemd",
+		"STOPPING=1 must not appear during an in-process reload; journal:\n%s", journal)
 	require.GreaterOrEqual(t, strings.Count(journal, "sent READY=1 to systemd"), 2,
 		"expected >=2 READY=1 log lines (boot + reload); journal:\n%s", journal)
 
-	// Shutdown flow
+	// Shutdown flow: systemctl stop SIGTERMs the process; the extension's
+	// termination handler must emit STOPPING=1 before the unit exits.
 	_ = execAndCollect(ctx, t, ctr, "systemctl", "stop", "otelcol.service")
 	stopped := execAndCollect(ctx, t, ctr,
 		"systemctl", "show", "otelcol.service",
@@ -297,6 +298,10 @@ func TestSDNotify_HappyPath_LifecycleIntegration(t *testing.T) {
 	require.Contains(t, stopped, "ActiveState=inactive")
 	require.Contains(t, stopped, "Result=success",
 		"unit should exit cleanly after systemctl stop; show:\n%s", stopped)
+
+	journal = execAndCollect(ctx, t, ctr, "journalctl", "-u", "otelcol.service", "--no-pager")
+	require.Contains(t, journal, "sent STOPPING=1 to systemd",
+		"expected STOPPING=1 log line after systemctl stop; journal:\n%s", journal)
 }
 
 // TestSDNotify_InvalidConfig_UnitFails verifies that when the collector config

--- a/extension/sdnotify/testdata/Dockerfile.badexporter
+++ b/extension/sdnotify/testdata/Dockerfile.badexporter
@@ -8,7 +8,11 @@ RUN mkdir -p /build/_out \
  && ocb --config=/src/extension/sdnotify/testdata/manifest.yaml \
  && test -x /build/_out/otelcol
 
-FROM ghcr.io/fauust/docker-systemd:debian-13 AS run-stage
+FROM debian:13 AS run-stage
+
+RUN apt-get update \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        systemd systemd-sysv procps ca-certificates
 
 COPY --from=build-stage /build/_out/otelcol /bin/otelcol
 

--- a/extension/sdnotify/testdata/Dockerfile.badexporter
+++ b/extension/sdnotify/testdata/Dockerfile.badexporter
@@ -1,9 +1,6 @@
-FROM golang:1.26.2 AS build-stage
+FROM otel/opentelemetry-collector-builder:0.155.0 AS build-stage
 
-ARG OCB_VERSION=v0.155.0
-RUN go install go.opentelemetry.io/collector/cmd/builder@${OCB_VERSION} && \
-    mv /go/bin/builder /usr/local/bin/ocb
-
+USER root
 WORKDIR /src
 COPY . /src
 
@@ -11,11 +8,7 @@ RUN mkdir -p /build/_out \
  && ocb --config=/src/extension/sdnotify/testdata/manifest.yaml \
  && test -x /build/_out/otelcol
 
-FROM debian:12 AS run-stage
-
-RUN apt-get update \
- && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        systemd systemd-sysv procps ca-certificates
+FROM ghcr.io/fauust/docker-systemd:debian-13 AS run-stage
 
 COPY --from=build-stage /build/_out/otelcol /bin/otelcol
 

--- a/extension/sdnotify/testdata/Dockerfile.happy
+++ b/extension/sdnotify/testdata/Dockerfile.happy
@@ -8,7 +8,11 @@ RUN mkdir -p /build/_out \
  && ocb --config=/src/extension/sdnotify/testdata/manifest.yaml \
  && test -x /build/_out/otelcol
 
-FROM ghcr.io/fauust/docker-systemd:debian-13 AS run-stage
+FROM debian:13 AS run-stage
+
+RUN apt-get update \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        systemd systemd-sysv procps ca-certificates
 
 COPY --from=build-stage /build/_out/otelcol /bin/otelcol
 

--- a/extension/sdnotify/testdata/Dockerfile.happy
+++ b/extension/sdnotify/testdata/Dockerfile.happy
@@ -1,9 +1,6 @@
-FROM golang:1.26.2 AS build-stage
+FROM otel/opentelemetry-collector-builder:0.155.0 AS build-stage
 
-ARG OCB_VERSION=v0.155.0
-RUN go install go.opentelemetry.io/collector/cmd/builder@${OCB_VERSION} && \
-    mv /go/bin/builder /usr/local/bin/ocb
-
+USER root
 WORKDIR /src
 COPY . /src
 
@@ -11,11 +8,7 @@ RUN mkdir -p /build/_out \
  && ocb --config=/src/extension/sdnotify/testdata/manifest.yaml \
  && test -x /build/_out/otelcol
 
-FROM debian:12 AS run-stage
-
-RUN apt-get update \
- && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        systemd systemd-sysv procps ca-certificates
+FROM ghcr.io/fauust/docker-systemd:debian-13 AS run-stage
 
 COPY --from=build-stage /build/_out/otelcol /bin/otelcol
 

--- a/extension/sdnotify/testdata/Dockerfile.invalidconfig
+++ b/extension/sdnotify/testdata/Dockerfile.invalidconfig
@@ -8,7 +8,11 @@ RUN mkdir -p /build/_out \
  && ocb --config=/src/extension/sdnotify/testdata/manifest.yaml \
  && test -x /build/_out/otelcol
 
-FROM ghcr.io/fauust/docker-systemd:debian-13 AS run-stage
+FROM debian:13 AS run-stage
+
+RUN apt-get update \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        systemd systemd-sysv procps ca-certificates
 
 COPY --from=build-stage /build/_out/otelcol /bin/otelcol
 

--- a/extension/sdnotify/testdata/Dockerfile.invalidconfig
+++ b/extension/sdnotify/testdata/Dockerfile.invalidconfig
@@ -1,9 +1,6 @@
-FROM golang:1.26.2 AS build-stage
+FROM otel/opentelemetry-collector-builder:0.155.0 AS build-stage
 
-ARG OCB_VERSION=v0.155.0
-RUN go install go.opentelemetry.io/collector/cmd/builder@${OCB_VERSION} && \
-    mv /go/bin/builder /usr/local/bin/ocb
-
+USER root
 WORKDIR /src
 COPY . /src
 
@@ -11,11 +8,7 @@ RUN mkdir -p /build/_out \
  && ocb --config=/src/extension/sdnotify/testdata/manifest.yaml \
  && test -x /build/_out/otelcol
 
-FROM debian:12 AS run-stage
-
-RUN apt-get update \
- && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        systemd systemd-sysv procps ca-certificates
+FROM ghcr.io/fauust/docker-systemd:debian-13 AS run-stage
 
 COPY --from=build-stage /build/_out/otelcol /bin/otelcol
 

--- a/extension/sdnotify/testdata/Dockerfile.nonotifysocket
+++ b/extension/sdnotify/testdata/Dockerfile.nonotifysocket
@@ -8,7 +8,11 @@ RUN mkdir -p /build/_out \
  && ocb --config=/src/extension/sdnotify/testdata/manifest.yaml \
  && test -x /build/_out/otelcol
 
-FROM ghcr.io/fauust/docker-systemd:debian-13 AS run-stage
+FROM debian:13 AS run-stage
+
+RUN apt-get update \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        systemd systemd-sysv procps ca-certificates
 
 COPY --from=build-stage /build/_out/otelcol /bin/otelcol
 

--- a/extension/sdnotify/testdata/Dockerfile.nonotifysocket
+++ b/extension/sdnotify/testdata/Dockerfile.nonotifysocket
@@ -1,9 +1,6 @@
-FROM golang:1.26.2 AS build-stage
+FROM otel/opentelemetry-collector-builder:0.155.0 AS build-stage
 
-ARG OCB_VERSION=v0.155.0
-RUN go install go.opentelemetry.io/collector/cmd/builder@${OCB_VERSION} && \
-    mv /go/bin/builder /usr/local/bin/ocb
-
+USER root
 WORKDIR /src
 COPY . /src
 
@@ -11,11 +8,7 @@ RUN mkdir -p /build/_out \
  && ocb --config=/src/extension/sdnotify/testdata/manifest.yaml \
  && test -x /build/_out/otelcol
 
-FROM debian:12 AS run-stage
-
-RUN apt-get update \
- && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        systemd systemd-sysv procps ca-certificates
+FROM ghcr.io/fauust/docker-systemd:debian-13 AS run-stage
 
 COPY --from=build-stage /build/_out/otelcol /bin/otelcol
 

--- a/extension/sdnotify/testdata/otelcol.service
+++ b/extension/sdnotify/testdata/otelcol.service
@@ -4,7 +4,7 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
-Type=notify
+Type=notify-reload
 NotifyAccess=main
 ExecStart=/bin/otelcol --config=/etc/otelcol/config.yaml
 TimeoutStartSec=60


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select kind for this pull request.
If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
Fixes a bug where the `sdnotify` extension emitted `STOPPING=1` during a `Type=notify-reload` in-process reload, which caused systemd to flip the unit into `deactivating` mid-reload and stall the entire reload cycle.

**Which issue(s) this PR fixes**:
Fixes #26

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Fixes a bug where the `sdnotify` extension emitted `STOPPING=1` during a `Type=notify-reload` in-process reload, which caused systemd to flip the unit into `deactivating` mid-reload and stall the entire reload cycle.
```
