### PR TITLE
Improve config validation

### DIFF
--- a/receiver/gardenerreceiver/config.go
+++ b/receiver/gardenerreceiver/config.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 type Config struct {
@@ -59,6 +60,9 @@ func validateKubeconfig(kubeconfig string) error {
 	}
 	if info.IsDir() {
 		return fmt.Errorf("kubeconfig %q must be a file, not a directory", kubeconfig)
+	}
+	if _, err := clientcmd.LoadFromFile(kubeconfig); err != nil {
+		return fmt.Errorf("kubeconfig %q is not valid: %w", kubeconfig, err)
 	}
 	return nil
 }

--- a/receiver/gardenerreceiver/config.go
+++ b/receiver/gardenerreceiver/config.go
@@ -6,8 +6,12 @@ package gardenerreceiver
 
 import (
 	"fmt"
+	"os"
 	"slices"
+	"strings"
 	"time"
+
+	"k8s.io/apimachinery/pkg/util/validation"
 )
 
 type Config struct {
@@ -26,7 +30,37 @@ func (cfg *Config) Validate() error {
 	if cfg.CollectionInterval <= 0 {
 		return fmt.Errorf("collection_interval must be positive")
 	}
+	if err := validateNamespace(cfg.Namespace); err != nil {
+		return err
+	}
+	if err := validateKubeconfig(cfg.Kubeconfig); err != nil {
+		return err
+	}
 	return validateResources(cfg.Resources)
+}
+
+func validateNamespace(namespace string) error {
+	if namespace == "" {
+		return nil
+	}
+	if errs := validation.IsDNS1123Label(namespace); len(errs) > 0 {
+		return fmt.Errorf("invalid namespace %q: %s", namespace, strings.Join(errs, "; "))
+	}
+	return nil
+}
+
+func validateKubeconfig(kubeconfig string) error {
+	if kubeconfig == "" {
+		return nil
+	}
+	info, err := os.Stat(kubeconfig)
+	if err != nil {
+		return fmt.Errorf("kubeconfig %q is not accessible: %w", kubeconfig, err)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("kubeconfig %q must be a file, not a directory", kubeconfig)
+	}
+	return nil
 }
 
 var validResources = []string{"shoots", "seeds", "projects", "managedseeds", "gardenlets"}

--- a/receiver/gardenerreceiver/config_test.go
+++ b/receiver/gardenerreceiver/config_test.go
@@ -5,6 +5,8 @@
 package gardenerreceiver
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -54,6 +56,66 @@ func TestConfigValidation_EmptyResource(t *testing.T) {
 	}
 	err := cfg.Validate()
 	require.NoError(t, err, "Validate() should succeed for empty resources")
+}
+
+func TestConfigValidation_ValidNamespace(t *testing.T) {
+	cfg := &Config{
+		CollectionInterval: 30 * time.Second,
+		Namespace:          "garden-my-project",
+	}
+	err := cfg.Validate()
+	require.NoError(t, err, "Validate() should succeed for a valid namespace")
+}
+
+func TestConfigValidation_EmptyNamespace(t *testing.T) {
+	cfg := &Config{
+		CollectionInterval: 30 * time.Second,
+		Namespace:          "",
+	}
+	err := cfg.Validate()
+	require.NoError(t, err, "Validate() should succeed for an empty namespace")
+}
+
+func TestConfigValidation_InvalidNamespace(t *testing.T) {
+	for _, ns := range []string{"Invalid_Namespace", "-leading-dash", "trailing-dash-", "has.dot", "UPPER"} {
+		cfg := &Config{
+			CollectionInterval: 30 * time.Second,
+			Namespace:          ns,
+		}
+		err := cfg.Validate()
+		require.Error(t, err, "Validate() should fail for invalid namespace %q", ns)
+	}
+}
+
+func TestConfigValidation_KubeconfigExists(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kubeconfig")
+	require.NoError(t, os.WriteFile(path, []byte("apiVersion: v1"), 0o600))
+
+	cfg := &Config{
+		CollectionInterval: 30 * time.Second,
+		Kubeconfig:         path,
+	}
+	err := cfg.Validate()
+	require.NoError(t, err, "Validate() should succeed when kubeconfig points to an existing file")
+}
+
+func TestConfigValidation_KubeconfigMissing(t *testing.T) {
+	cfg := &Config{
+		CollectionInterval: 30 * time.Second,
+		Kubeconfig:         filepath.Join(t.TempDir(), "does-not-exist"),
+	}
+	err := cfg.Validate()
+	require.Error(t, err, "Validate() should fail when kubeconfig does not exist")
+}
+
+func TestConfigValidation_KubeconfigIsDirectory(t *testing.T) {
+	cfg := &Config{
+		CollectionInterval: 30 * time.Second,
+		Kubeconfig:         t.TempDir(),
+	}
+	err := cfg.Validate()
+	require.Error(t, err, "Validate() should fail when kubeconfig points to a directory")
 }
 
 func TestHasShootResource(t *testing.T) {

--- a/receiver/gardenerreceiver/config_test.go
+++ b/receiver/gardenerreceiver/config_test.go
@@ -90,14 +90,32 @@ func TestConfigValidation_InvalidNamespace(t *testing.T) {
 func TestConfigValidation_KubeconfigExists(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "kubeconfig")
-	require.NoError(t, os.WriteFile(path, []byte("apiVersion: v1"), 0o600))
+	require.NoError(t, os.WriteFile(path, []byte(`apiVersion: v1
+kind: Config
+clusters: []
+contexts: []
+users: []
+`), 0o600))
 
 	cfg := &Config{
 		CollectionInterval: 30 * time.Second,
 		Kubeconfig:         path,
 	}
 	err := cfg.Validate()
-	require.NoError(t, err, "Validate() should succeed when kubeconfig points to an existing file")
+	require.NoError(t, err, "Validate() should succeed when kubeconfig points to a valid kubeconfig file")
+}
+
+func TestConfigValidation_KubeconfigMalformed(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kubeconfig")
+	require.NoError(t, os.WriteFile(path, []byte("apiVersion: ["), 0o600))
+
+	cfg := &Config{
+		CollectionInterval: 30 * time.Second,
+		Kubeconfig:         path,
+	}
+	err := cfg.Validate()
+	require.Error(t, err, "Validate() should fail when kubeconfig is malformed")
 }
 
 func TestConfigValidation_KubeconfigMissing(t *testing.T) {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select kind for this pull request.
If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind enhancement

**What this PR does / why we need it**:
Add the following config validations to the Gardener receiver:
- The Kubeconfig property has to reference an existing file
- A Namespace filter has to follow Kubernetes' naming restrictions for namespaces

**Which issue(s) this PR fixes**:
https://github.com/gardener/observability/issues/57

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Add config validations for Kubeconfig and Namespace in Gardener receiver
```
