### PR TITLE
fix(sdnotify): send STOPPING=1 reliably on shutdown.

### DIFF
--- a/extension/sdnotify/sdnotify.go
+++ b/extension/sdnotify/sdnotify.go
@@ -66,6 +66,8 @@ func (s *sdnotify) Start(_ context.Context, host component.Host) error {
 	// "context canceled" rather than the signal, and we'd miss sending STOPPING=1.
 	// Instead we watch the signal directly and use done to tell a real signal
 	// apart from a graceful Shutdown().
+	//
+	// For more context: https://github.com/open-telemetry/opentelemetry-collector/issues/15732
 	signal.Notify(s.termCh, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		select {

--- a/extension/sdnotify/sdnotify.go
+++ b/extension/sdnotify/sdnotify.go
@@ -62,6 +62,10 @@ func (s *sdnotify) Start(startCtx context.Context, host component.Host) error {
 
 		// We don't want to send STOPPING=1, if we call s.cancel().
 		errStr := context.Cause(s.ctx).Error()
+		s.logger.Info(
+			"Collector shuts down",
+			zap.String("cause", errStr),
+		)
 		if errStr == syscall.SIGINT.String()+" signal received" || errStr == syscall.SIGTERM.String()+" signal received" {
 			sent, err := daemon.SdNotify(false, daemon.SdNotifyStopping)
 			if err != nil {

--- a/extension/sdnotify/sdnotify.go
+++ b/extension/sdnotify/sdnotify.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 	"time"
 
@@ -24,9 +25,10 @@ type sdnotify struct {
 	logger *zap.Logger
 	host   component.Host
 
-	ctx    context.Context
-	cancel context.CancelFunc
-	sigCh  chan os.Signal
+	shutdownOnce sync.Once
+	done         chan struct{}
+	termCh       chan os.Signal
+	sighupCh     chan os.Signal
 }
 
 // Extension is the union of capability interfaces sdnotify implements.
@@ -39,13 +41,15 @@ var _ Extension = (*sdnotify)(nil)
 
 func newSDNotify(cfg *Config, logger *zap.Logger) *sdnotify {
 	return &sdnotify{
-		cfg:    cfg,
-		logger: logger,
-		sigCh:  make(chan os.Signal, 1),
+		cfg:      cfg,
+		logger:   logger,
+		done:     make(chan struct{}),
+		termCh:   make(chan os.Signal, 1),
+		sighupCh: make(chan os.Signal, 1),
 	}
 }
 
-func (s *sdnotify) Start(startCtx context.Context, host component.Host) error {
+func (s *sdnotify) Start(_ context.Context, host component.Host) error {
 	s.host = host
 
 	// If NOTIFY_SOCKET environment variable is unset, then the sd_notify protocol is no-op.
@@ -56,22 +60,21 @@ func (s *sdnotify) Start(startCtx context.Context, host component.Host) error {
 	}
 
 	// STOPPING=1 must be sent only on genuine termination (SIGINT / SIGTERM).
-	s.ctx, s.cancel = signal.NotifyContext(startCtx, syscall.SIGINT, syscall.SIGTERM)
+	// signal.NotifyContext could be used here, but the otel collector has its own
+	// SIGINT / SIGTERM handler. Listening for a cancelled context would race it:
+	// if the collector's Shutdown() cancelled our context first, context.Cause is
+	// "context canceled" rather than the signal, and we'd miss sending STOPPING=1.
+	// Instead we watch the signal directly and use done to tell a real signal
+	// apart from a graceful Shutdown().
+	signal.Notify(s.termCh, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
-		<-s.ctx.Done()
-
-		// We don't want to send STOPPING=1, if we call s.cancel().
-		errStr := context.Cause(s.ctx).Error()
-		s.logger.Info(
-			"Collector shuts down",
-			zap.String("cause", errStr),
-		)
-		if errStr == syscall.SIGINT.String()+" signal received" || errStr == syscall.SIGTERM.String()+" signal received" {
+		select {
+		case <-s.done:
+			return
+		case <-s.termCh:
 			sent, err := daemon.SdNotify(false, daemon.SdNotifyStopping)
 			if err != nil {
 				s.logger.Warn("sdnotify STOPPING=1 failed", zap.Error(err))
-
-				return
 			} else if sent {
 				s.logger.Info("sdnotify: sent STOPPING=1 to systemd")
 			}
@@ -83,15 +86,15 @@ func (s *sdnotify) Start(startCtx context.Context, host component.Host) error {
 	// The process is responsible for reloading its configuration and informing
 	// systemd when the reload has completed.
 	monotonicEpoch := time.Now()
-	signal.Notify(s.sigCh, syscall.SIGHUP)
+	signal.Notify(s.sighupCh, syscall.SIGHUP)
 	go func() {
 		for {
 			select {
-			case <-s.ctx.Done():
+			case <-s.done:
 				return
 
 			// This extension should not restart the process, because the collector handles it by itself.
-			case <-s.sigCh:
+			case <-s.sighupCh:
 				// Per sd_notify(3): MONOTONIC_USEC must be CLOCK_MONOTONIC in microseconds,
 				// formatted as a decimal string, in the same datagram as RELOADING=1.
 				monotonicUSec := uint64(max(time.Since(monotonicEpoch), 0) / time.Microsecond)
@@ -131,7 +134,7 @@ func (s *sdnotify) Start(startCtx context.Context, host component.Host) error {
 			defer ticker.Stop()
 			for {
 				select {
-				case <-s.ctx.Done():
+				case <-s.done:
 					return
 				case <-ticker.C:
 					if _, err := daemon.SdNotify(false, daemon.SdNotifyWatchdog); err != nil {
@@ -146,11 +149,11 @@ func (s *sdnotify) Start(startCtx context.Context, host component.Host) error {
 }
 
 func (s *sdnotify) Shutdown(_ context.Context) error {
-	if s.cancel != nil {
-		// This extension should not stop the process, because the collector handles it by itself.
-		signal.Stop(s.sigCh)
-		s.cancel()
-	}
+	s.shutdownOnce.Do(func() {
+		signal.Stop(s.termCh)
+		signal.Stop(s.sighupCh)
+		close(s.done)
+	})
 
 	return nil
 }

--- a/extension/sdnotify/sdnotify.go
+++ b/extension/sdnotify/sdnotify.go
@@ -60,21 +60,13 @@ func (s *sdnotify) Start(startCtx context.Context, host component.Host) error {
 	go func() {
 		<-s.ctx.Done()
 
-		// We don't want to send STOPPING=1, if we call s.cancel().
-		errStr := context.Cause(s.ctx).Error()
-		s.logger.Info(
-			"Collector shuts down",
-			zap.String("cause", errStr),
-		)
-		if errStr == syscall.SIGINT.String()+" signal received" || errStr == syscall.SIGTERM.String()+" signal received" {
-			sent, err := daemon.SdNotify(false, daemon.SdNotifyStopping)
-			if err != nil {
-				s.logger.Warn("sdnotify STOPPING=1 failed", zap.Error(err))
+		sent, err := daemon.SdNotify(false, daemon.SdNotifyStopping)
+		if err != nil {
+			s.logger.Warn("sdnotify STOPPING=1 failed", zap.Error(err))
 
-				return
-			} else if sent {
-				s.logger.Info("sdnotify: sent STOPPING=1 to systemd")
-			}
+			return
+		} else if sent {
+			s.logger.Info("sdnotify: sent STOPPING=1 to systemd")
 		}
 	}()
 

--- a/extension/sdnotify/sdnotify.go
+++ b/extension/sdnotify/sdnotify.go
@@ -60,13 +60,21 @@ func (s *sdnotify) Start(startCtx context.Context, host component.Host) error {
 	go func() {
 		<-s.ctx.Done()
 
-		sent, err := daemon.SdNotify(false, daemon.SdNotifyStopping)
-		if err != nil {
-			s.logger.Warn("sdnotify STOPPING=1 failed", zap.Error(err))
+		// We don't want to send STOPPING=1, if we call s.cancel().
+		errStr := context.Cause(s.ctx).Error()
+		s.logger.Info(
+			"Collector shuts down",
+			zap.String("cause", errStr),
+		)
+		if errStr == syscall.SIGINT.String()+" signal received" || errStr == syscall.SIGTERM.String()+" signal received" {
+			sent, err := daemon.SdNotify(false, daemon.SdNotifyStopping)
+			if err != nil {
+				s.logger.Warn("sdnotify STOPPING=1 failed", zap.Error(err))
 
-			return
-		} else if sent {
-			s.logger.Info("sdnotify: sent STOPPING=1 to systemd")
+				return
+			} else if sent {
+				s.logger.Info("sdnotify: sent STOPPING=1 to systemd")
+			}
 		}
 	}()
 

--- a/extension/sdnotify/sdnotify_test.go
+++ b/extension/sdnotify/sdnotify_test.go
@@ -335,9 +335,11 @@ func TestSDNotify_HappyPath_LifecycleIntegration(t *testing.T) {
 	require.Contains(t, stopped, "Result=success",
 		"unit should exit cleanly after systemctl stop; show:\n%s", stopped)
 
-	journal = execAndCollect(ctx, t, ctr, "journalctl", "-u", "otelcol.service", "--no-pager")
-	require.Contains(t, journal, "sent STOPPING=1 to systemd",
-		"expected STOPPING=1 log line after systemctl stop; journal:\n%s", journal)
+	require.Eventually(t, func() bool {
+		journal := execAndCollect(ctx, t, ctr, "journalctl", "-u", "otelcol.service", "--no-pager")
+		return strings.Contains(journal, "sent STOPPING=1 to systemd")
+	}, 15*time.Second, 200*time.Millisecond,
+		"expected STOPPING=1 log line after systemctl stop")
 }
 
 // TestSDNotify_InvalidConfig_UnitFails verifies that when the collector config

--- a/extension/sdnotify/sdnotify_test.go
+++ b/extension/sdnotify/sdnotify_test.go
@@ -314,15 +314,19 @@ func TestSDNotify_HappyPath_LifecycleIntegration(t *testing.T) {
 		"MainPID must not change on in-process reload; before=%s after=%s", beforePID, afterPID)
 
 	// Reload journal: RELOADING=1 + >=2 READY=1 - the second is the post-reload
-	// ready. STOPPING=1 must NOT appear yet - the extension only emits it on
-	// genuine termination (SIGINT / SIGTERM), never mid-reload.
-	journal := execAndCollect(ctx, t, ctr, "journalctl", "-u", "otelcol.service", "--no-pager")
-	require.Contains(t, journal, "sent RELOADING=1 to systemd",
-		"expected RELOADING=1 log line after SIGHUP; journal:\n%s", journal)
+	// ready. The unit flips back to active before those log lines are guaranteed
+	// to be flushed to journald, so poll for them rather than reading once.
+	var journal string
+	require.Eventually(t, func() bool {
+		journal = execAndCollect(ctx, t, ctr, "journalctl", "-u", "otelcol.service", "--no-pager")
+		return strings.Contains(journal, "sent RELOADING=1 to systemd") &&
+			strings.Count(journal, "sent READY=1 to systemd") >= 2
+	}, 15*time.Second, 200*time.Millisecond,
+		"expected RELOADING=1 + >=2 READY=1 (boot + reload) log lines after SIGHUP")
+	// STOPPING=1 must NOT appear - the extension only emits it on genuine
+	// termination (SIGINT / SIGTERM), never mid-reload.
 	require.NotContains(t, journal, "sent STOPPING=1 to systemd",
 		"STOPPING=1 must not appear during an in-process reload; journal:\n%s", journal)
-	require.GreaterOrEqual(t, strings.Count(journal, "sent READY=1 to systemd"), 2,
-		"expected >=2 READY=1 log lines (boot + reload); journal:\n%s", journal)
 
 	// Shutdown flow: systemctl stop SIGTERMs the process; the extension's
 	// termination handler must emit STOPPING=1 before the unit exits.
@@ -399,9 +403,13 @@ func TestSDNotify_BadExporter_ReachesReady(t *testing.T) {
 	require.Contains(t, show, "ActiveState=active",
 		"unit should be active even when the exporter target is unreachable; show:\n%s", show)
 
-	journal := execAndCollect(ctx, t, ctr, "journalctl", "-u", "otelcol.service", "--no-pager")
-	require.Contains(t, journal, "sent READY=1 to systemd",
-		"expected READY=1 to be emitted with an unreachable exporter; journal:\n%s", journal)
+	// The unit is active before the READY=1 log line is guaranteed flushed to
+	// journald, so poll for it rather than reading once.
+	require.Eventually(t, func() bool {
+		journal := execAndCollect(ctx, t, ctr, "journalctl", "-u", "otelcol.service", "--no-pager")
+		return strings.Contains(journal, "sent READY=1 to systemd")
+	}, 15*time.Second, 200*time.Millisecond,
+		"expected READY=1 to be emitted with an unreachable exporter")
 }
 
 // TestSDNotify_NoNotifySocket_NoopBranch verifies the extension's no-op

--- a/extension/sdnotify/sdnotify_test.go
+++ b/extension/sdnotify/sdnotify_test.go
@@ -314,19 +314,15 @@ func TestSDNotify_HappyPath_LifecycleIntegration(t *testing.T) {
 		"MainPID must not change on in-process reload; before=%s after=%s", beforePID, afterPID)
 
 	// Reload journal: RELOADING=1 + >=2 READY=1 - the second is the post-reload
-	// ready. The unit flips back to active before those log lines are guaranteed
-	// to be flushed to journald, so poll for them rather than reading once.
-	var journal string
-	require.Eventually(t, func() bool {
-		journal = execAndCollect(ctx, t, ctr, "journalctl", "-u", "otelcol.service", "--no-pager")
-		return strings.Contains(journal, "sent RELOADING=1 to systemd") &&
-			strings.Count(journal, "sent READY=1 to systemd") >= 2
-	}, 15*time.Second, 200*time.Millisecond,
-		"expected RELOADING=1 + >=2 READY=1 (boot + reload) log lines after SIGHUP")
-	// STOPPING=1 must NOT appear - the extension only emits it on genuine
-	// termination (SIGINT / SIGTERM), never mid-reload.
+	// ready. STOPPING=1 must NOT appear yet - the extension only emits it on
+	// genuine termination (SIGINT / SIGTERM), never mid-reload.
+	journal := execAndCollect(ctx, t, ctr, "journalctl", "-u", "otelcol.service", "--no-pager")
+	require.Contains(t, journal, "sent RELOADING=1 to systemd",
+		"expected RELOADING=1 log line after SIGHUP; journal:\n%s", journal)
 	require.NotContains(t, journal, "sent STOPPING=1 to systemd",
 		"STOPPING=1 must not appear during an in-process reload; journal:\n%s", journal)
+	require.GreaterOrEqual(t, strings.Count(journal, "sent READY=1 to systemd"), 2,
+		"expected >=2 READY=1 log lines (boot + reload); journal:\n%s", journal)
 
 	// Shutdown flow: systemctl stop SIGTERMs the process; the extension's
 	// termination handler must emit STOPPING=1 before the unit exits.
@@ -403,13 +399,9 @@ func TestSDNotify_BadExporter_ReachesReady(t *testing.T) {
 	require.Contains(t, show, "ActiveState=active",
 		"unit should be active even when the exporter target is unreachable; show:\n%s", show)
 
-	// The unit is active before the READY=1 log line is guaranteed flushed to
-	// journald, so poll for it rather than reading once.
-	require.Eventually(t, func() bool {
-		journal := execAndCollect(ctx, t, ctr, "journalctl", "-u", "otelcol.service", "--no-pager")
-		return strings.Contains(journal, "sent READY=1 to systemd")
-	}, 15*time.Second, 200*time.Millisecond,
-		"expected READY=1 to be emitted with an unreachable exporter")
+	journal := execAndCollect(ctx, t, ctr, "journalctl", "-u", "otelcol.service", "--no-pager")
+	require.Contains(t, journal, "sent READY=1 to systemd",
+		"expected READY=1 to be emitted with an unreachable exporter; journal:\n%s", journal)
 }
 
 // TestSDNotify_NoNotifySocket_NoopBranch verifies the extension's no-op

--- a/extension/sdnotify/sdnotify_test.go
+++ b/extension/sdnotify/sdnotify_test.go
@@ -335,11 +335,9 @@ func TestSDNotify_HappyPath_LifecycleIntegration(t *testing.T) {
 	require.Contains(t, stopped, "Result=success",
 		"unit should exit cleanly after systemctl stop; show:\n%s", stopped)
 
-	require.Eventually(t, func() bool {
-		journal := execAndCollect(ctx, t, ctr, "journalctl", "-u", "otelcol.service", "--no-pager")
-		return strings.Contains(journal, "sent STOPPING=1 to systemd")
-	}, 15*time.Second, 200*time.Millisecond,
-		"expected STOPPING=1 log line after systemctl stop")
+	journal = execAndCollect(ctx, t, ctr, "journalctl", "-u", "otelcol.service", "--no-pager")
+	require.Contains(t, journal, "sent STOPPING=1 to systemd",
+		"expected STOPPING=1 log line after systemctl stop; journal:\n%s", journal)
 }
 
 // TestSDNotify_InvalidConfig_UnitFails verifies that when the collector config


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select kind for this pull request.
If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug

**What this PR does / why we need it**:
 On SIGTERM, two things cancel the same signal.NotifyContext context:
  - the OS signal (cause: "terminated signal received"), and
  - the collector's own shutdown path calling the extension's Shutdown() → s.cancel() (cause: context.Canceled).
This leads to that in some conditions STOPPING signal was not sent at all. This PR introduces custom channels to handle cancel signals.

**Which issue(s) this PR fixes**:
Fixes #26 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Send STOPPING=1 reliably on shutdown.
```
